### PR TITLE
Add tablet-repair, pc-repair, data-recovery landing pages with full SEO

### DIFF
--- a/about.html
+++ b/about.html
@@ -490,6 +490,9 @@
                         <li><a href="iphone-repair.html">iPhone Repair</a></li>
                         <li><a href="console-repair.html">Console Repair</a></li>
                         <li><a href="macbook-repair.html">MacBook Repair</a></li>
+                        <li><a href="tablet-repair.html">Tablet Repair</a></li>
+                        <li><a href="pc-repair.html">PC Repair</a></li>
+                        <li><a href="data-recovery.html">Data Recovery</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>

--- a/console-repair.html
+++ b/console-repair.html
@@ -834,6 +834,20 @@
                 </div>
             </div>
         </section>
+        <!-- Other Services Cross-Links -->
+        <section style="padding: 3rem 0; border-top: 2px solid var(--hex-black); background: var(--hex-concrete);" aria-label="Other repair services">
+            <div class="container">
+                <h2 style="font-size: clamp(1.3rem, 3vw, 1.8rem); font-weight: 900; text-transform: uppercase; text-align: center; margin-bottom: 0.5rem;">"OTHER SERVICES"</h2>
+                <p style="text-align: center; font-family: monospace; color: #666; font-size: 0.85rem; margin-bottom: 2rem; text-transform: uppercase;">We repair more than just consoles</p>
+                <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; max-width: 900px; margin: 0 auto;">
+                    <a href="iphone-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-mobile-alt" aria-hidden="true" style="color: var(--hex-accent);"></i> iPhone Repair</a>
+                    <a href="macbook-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-laptop" aria-hidden="true" style="color: var(--hex-accent);"></i> MacBook Repair</a>
+                    <a href="tablet-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-tablet-alt" aria-hidden="true" style="color: var(--hex-accent);"></i> Tablet Repair</a>
+                    <a href="pc-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-desktop" aria-hidden="true" style="color: var(--hex-accent);"></i> PC Repair</a>
+                    <a href="data-recovery.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-hdd" aria-hidden="true" style="color: var(--hex-accent);"></i> Data Recovery</a>
+                </div>
+            </div>
+        </section>
     </main>
 
     <!-- Footer -->
@@ -856,6 +870,9 @@
                         <li><a href="iphone-repair.html">iPhone Repair</a></li>
                         <li><a href="console-repair.html">Console Repair</a></li>
                         <li><a href="macbook-repair.html">MacBook Repair</a></li>
+                        <li><a href="tablet-repair.html">Tablet Repair</a></li>
+                        <li><a href="pc-repair.html">PC Repair</a></li>
+                        <li><a href="data-recovery.html">Data Recovery</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>

--- a/contact.html
+++ b/contact.html
@@ -489,6 +489,9 @@
                         <li><a href="iphone-repair.html">iPhone Repair</a></li>
                         <li><a href="console-repair.html">Console Repair</a></li>
                         <li><a href="macbook-repair.html">MacBook Repair</a></li>
+                        <li><a href="tablet-repair.html">Tablet Repair</a></li>
+                        <li><a href="pc-repair.html">PC Repair</a></li>
+                        <li><a href="data-recovery.html">Data Recovery</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>

--- a/data-recovery.html
+++ b/data-recovery.html
@@ -11,13 +11,13 @@
     <!-- Security & Privacy -->
     <meta name="referrer" content="strict-origin-when-cross-origin">
 
-    <!-- SEO Meta Tags - MACBOOK REPAIR LANDING PAGE -->
-    <title>MacBook Repair Guildford | Logic Board &amp; Screen Fix Surrey | Same-Day | OnlineFix</title>
-    <meta name="description" content="Expert MacBook repair in Guildford, Surrey. Logic board repair, screen replacement, SSD upgrade, battery swap, keyboard fix. Same-day service — by appointment only. No fix, no fee. 90-day warranty. Call 07940 730537.">
-    <meta name="keywords" content="MacBook repair Guildford, MacBook screen replacement Surrey, MacBook logic board repair, MacBook battery replacement Guildford, MacBook Pro repair near me, MacBook Air repair Guildford, laptop repair Guildford, MacBook keyboard repair, MacBook SSD upgrade, MacBook not turning on, MacBook water damage repair, MacBook repair Woking, MacBook repair Godalming, MacBook repair Farnham, no fix no fee laptop repair">
+    <!-- SEO Meta Tags - DATA RECOVERY LANDING PAGE -->
+    <title>Data Recovery Guildford | Hard Drive &amp; SSD Recovery Surrey | OnlineFix</title>
+    <meta name="description" content="Professional data recovery in Guildford, Surrey. Hard drive recovery, SSD data recovery, USB and phone data retrieval. By appointment only. No data, no fee. Fully confidential service. Call 07940 730537.">
+    <meta name="keywords" content="data recovery Guildford, hard drive recovery Surrey, SSD data recovery, USB recovery, memory card recovery, phone data recovery, laptop data recovery, RAID recovery, no data no fee, confidential data recovery, data recovery near me, data recovery Woking, data recovery Godalming, data recovery Farnham, hard drive not detected, deleted file recovery Guildford">
     <meta name="author" content="OnlineFix - Tomas">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
-    <link rel="canonical" href="https://onlinefix.co.uk/macbook-repair.html">
+    <link rel="canonical" href="https://onlinefix.co.uk/data-recovery.html">
     <link rel="sitemap" type="application/xml" href="/sitemap.xml">
 
     <!-- Local SEO Geo-Tags -->
@@ -28,20 +28,20 @@
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://onlinefix.co.uk/macbook-repair.html">
+    <meta property="og:url" content="https://onlinefix.co.uk/data-recovery.html">
     <meta property="og:site_name" content="OnlineFix Guildford">
-    <meta property="og:title" content="MacBook Repair Guildford | Logic Board & Screen Fix | No Fix No Fee">
-    <meta property="og:description" content="Broken MacBook? No fix, no fee. Expert MacBook Pro & Air repair in Guildford. Logic board, screen, battery, keyboard & SSD repairs. Same-day service. 90-day warranty.">
+    <meta property="og:title" content="Data Recovery Guildford | Hard Drive & SSD Recovery | No Data No Fee">
+    <meta property="og:description" content="Lost data? No data, no fee. Professional hard drive, SSD, USB and phone data recovery in Guildford. Fully confidential service. Call to book a drop-off.">
     <meta property="og:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="OnlineFix MacBook Repair - Logic Board Screen Battery Repair Guildford">
+    <meta property="og:image:alt" content="OnlineFix Data Recovery - Hard Drive SSD USB Phone Recovery Guildford">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://onlinefix.co.uk/macbook-repair.html">
-    <meta property="twitter:title" content="MacBook Repair Guildford | Same-Day Fix | No Fix No Fee">
-    <meta property="twitter:description" content="MacBook Pro & Air repair in Guildford. Logic board, screen, battery, keyboard & SSD. Same-day service. 90-day warranty. Appointment only.">
+    <meta property="twitter:url" content="https://onlinefix.co.uk/data-recovery.html">
+    <meta property="twitter:title" content="Data Recovery Guildford | Hard Drive & SSD | No Data No Fee">
+    <meta property="twitter:description" content="Hard drive, SSD, USB &amp; phone data recovery in Guildford. Confidential service. No data, no fee. By appointment only.">
     <meta property="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
 
     <!-- Favicon -->
@@ -80,8 +80,8 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "MacBook Repair",
-                "item": "https://onlinefix.co.uk/macbook-repair.html"
+                "name": "Data Recovery",
+                "item": "https://onlinefix.co.uk/data-recovery.html"
             }
         ]
     }
@@ -92,9 +92,9 @@
     {
         "@context": "https://schema.org",
         "@type": "WebPage",
-        "name": "MacBook Repair Guildford | Logic Board & Screen Fix Surrey",
-        "description": "No fix, no fee MacBook repair in Guildford, Surrey. Same-day MacBook Pro and MacBook Air repair. Logic board repair, screen replacement, SSD upgrade, battery swap, keyboard fix, water damage recovery. 90-day warranty. Serving Guildford, Woking, Godalming and Farnham.",
-        "url": "https://onlinefix.co.uk/macbook-repair.html",
+        "name": "Data Recovery Guildford | Hard Drive & SSD Recovery Surrey",
+        "description": "No data, no fee data recovery in Guildford, Surrey. Professional hard drive, SSD, USB, and phone data recovery. Fully confidential service. Serving Guildford, Woking, Godalming and Farnham.",
+        "url": "https://onlinefix.co.uk/data-recovery.html",
         "isPartOf": {
             "@type": "WebSite",
             "name": "OnlineFix",
@@ -108,18 +108,18 @@
             "itemListElement": [
                 {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://onlinefix.co.uk/"},
                 {"@type": "ListItem", "position": 2, "name": "Services", "item": "https://onlinefix.co.uk/services.html"},
-                {"@type": "ListItem", "position": 3, "name": "MacBook Repair", "item": "https://onlinefix.co.uk/macbook-repair.html"}
+                {"@type": "ListItem", "position": 3, "name": "Data Recovery", "item": "https://onlinefix.co.uk/data-recovery.html"}
             ]
         }
     }
     </script>
 
-    <!-- Service Schema - MacBook Repair -->
+    <!-- Service Schema - Data Recovery -->
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
         "@type": "Service",
-        "serviceType": "MacBook Repair",
+        "serviceType": "Data Recovery",
         "provider": {
             "@type": "LocalBusiness",
             "@id": "https://onlinefix.co.uk/#organization",
@@ -133,54 +133,54 @@
         ],
         "hasOfferCatalog": {
             "@type": "OfferCatalog",
-            "name": "MacBook Repair Services",
+            "name": "Data Recovery Services",
             "itemListElement": [
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Logic Board Repair",
-                        "description": "Professional board-level repair for MacBook Pro and MacBook Air with no power, no backlight, kernel panics, or GPU failure using micro-soldering"
+                        "name": "Accidental Deletion Recovery",
+                        "description": "Recovery of accidentally deleted files, emptied recycle bin contents, and formatted drive data from hard drives, SSDs, and USB devices"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Screen Replacement",
-                        "description": "LCD and Retina display replacement for cracked, dead pixel, or flickering MacBook screens including MacBook Pro and MacBook Air models"
+                        "name": "Hard Drive Failure Recovery",
+                        "description": "Data recovery from failed, clicking, or undetected hard drives including mechanical failure, head crashes, and motor seizure"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Battery Replacement",
-                        "description": "Genuine-spec battery replacement for MacBook Pro and MacBook Air with swollen battery, poor battery life, or not charging issues"
+                        "name": "SSD Data Recovery",
+                        "description": "Professional data recovery from dead or corrupted solid state drives including SATA, NVMe, and M.2 SSDs with firmware-level recovery"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Keyboard Repair",
-                        "description": "Keyboard replacement and repair for stuck, unresponsive, or butterfly mechanism MacBook keyboards including top case replacement"
+                        "name": "Water and Fire Damage Recovery",
+                        "description": "Data recovery from water-damaged, flood-damaged, or fire-damaged storage devices with specialist cleaning and component-level repair"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook SSD Upgrade & Data Recovery",
-                        "description": "SSD storage upgrade and data recovery for MacBook Pro and MacBook Air, including transfer from failing drives"
+                        "name": "Phone Data Recovery",
+                        "description": "Data retrieval from dead, broken, or water-damaged smartphones including iPhone and Android devices with broken screens or no power"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Water Damage Repair",
-                        "description": "Liquid damage diagnosis and board-level repair for MacBook Pro and MacBook Air with corrosion cleaning and component replacement"
+                        "name": "RAID and Server Recovery",
+                        "description": "RAID array and NAS data recovery for failed server configurations including RAID 0, RAID 1, RAID 5, and RAID 6 rebuilds"
                     }
                 }
             ]
@@ -188,7 +188,7 @@
     }
     </script>
 
-    <!-- FAQ Schema - MacBook Repair -->
+    <!-- FAQ Schema - Data Recovery -->
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
@@ -196,50 +196,50 @@
         "mainEntity": [
             {
                 "@type": "Question",
-                "name": "How much does a MacBook screen replacement cost in Guildford?",
+                "name": "What is the success rate for data recovery?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "MacBook screen replacement at OnlineFix Guildford starts from £149 depending on the model. MacBook Air screens are typically less expensive than MacBook Pro Retina displays. The price includes the replacement display, professional fitting, and full testing. We operate a no fix, no fee policy and all repairs include a 90-day warranty."
+                    "text": "Our data recovery success rate is approximately 90% across all device types. Logical failures such as accidental deletion and formatting have the highest recovery rates, often close to 100%. Mechanical hard drive failures and water-damaged devices have slightly lower rates depending on the severity. We operate a no data, no fee policy — if we cannot recover your data, you do not pay."
                 }
             },
             {
                 "@type": "Question",
-                "name": "Can you fix a MacBook that won't turn on?",
+                "name": "How much does data recovery cost in Guildford?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes. A MacBook that won't turn on is usually caused by a faulty logic board, failed power IC, liquid damage, or a dead battery. At OnlineFix we diagnose the exact cause with board-level testing equipment and only charge for the specific repair needed. Most power-related MacBook repairs are completed within 24-48 hours."
+                    "text": "Data recovery at OnlineFix Guildford starts from £45 for straightforward deleted file recovery. Hard drive failure recovery starts from £55, SSD recovery from £65, and RAID or server recovery from £85. We provide a fixed quote after diagnosis before any work begins. No data, no fee — you only pay if we successfully recover your files."
                 }
             },
             {
                 "@type": "Question",
-                "name": "Do you repair water-damaged MacBooks?",
+                "name": "How long does data recovery take?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes, we specialise in MacBook liquid damage repair. We perform ultrasonic cleaning of the logic board, replace corroded components using micro-soldering, and restore full functionality. The sooner you bring it in after a spill, the better the chances of a full recovery. No fix, no fee — if we can't save it, you don't pay."
+                    "text": "Simple deleted file recovery can often be completed within 24 hours. Hard drive and SSD recovery typically takes 2-5 working days depending on the severity of the failure. RAID and server recovery may take up to 7 working days. We offer a 24-hour priority service for urgent cases. You will receive a time estimate when you book your drop-off."
                 }
             },
             {
                 "@type": "Question",
-                "name": "How long does a MacBook repair take?",
+                "name": "Is my data kept confidential during recovery?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Most MacBook repairs at OnlineFix Guildford are completed same-day or within 1-3 days. Battery and SSD swaps are typically same-day. Screen replacements and keyboard repairs take 24-48 hours. Logic board repairs may take 2-3 days for thorough diagnosis and testing. Unlike Apple Store or chains who send MacBooks away for weeks, we repair on-site in Guildford."
+                    "text": "Absolutely. Confidentiality is central to our data recovery service. We never browse, copy, or share your recovered files. Your data is handled on secure, isolated systems. Once recovery is complete and you have verified your files, all working copies are securely wiped from our systems. We are happy to sign a non-disclosure agreement if required."
                 }
             },
             {
                 "@type": "Question",
-                "name": "Is it worth repairing an old MacBook?",
+                "name": "What devices can you recover data from?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Often yes. An SSD upgrade and battery replacement can make a 2015-2019 MacBook feel brand new for a fraction of the cost of a replacement. We provide honest advice — if a repair doesn't make economic sense, we'll tell you upfront during our free diagnosis. No fix, no fee means zero risk to you."
+                    "text": "We recover data from virtually all storage devices including internal and external hard drives (HDD), solid state drives (SSD, NVMe, M.2), USB flash drives, SD cards, microSD cards, iPhones, Android phones, laptops, MacBooks, RAID arrays, and NAS devices. If your data was stored on it, we can almost certainly attempt recovery."
                 }
             },
             {
                 "@type": "Question",
-                "name": "Is there a warranty on MacBook repairs?",
+                "name": "Should I attempt recovery myself before bringing it in?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes, all MacBook repairs at OnlineFix come with a 90-day warranty. We also operate a no fix, no fee policy — if we can't repair your MacBook, you don't pay. We stand behind our work and use quality replacement parts. If the same issue recurs within the 90-day warranty period, we'll fix it at no additional cost."
+                    "text": "We strongly recommend against DIY recovery attempts. Running a failed hard drive, installing recovery software on the affected drive, or opening a drive outside a clean environment can permanently destroy data. The best course of action is to power off the device immediately and book a drop-off with us. The less the device is used after data loss, the higher the chance of successful recovery."
                 }
             }
         ]
@@ -287,19 +287,19 @@
 
         /* PAGE HEADER */
         .page-header { padding: 60px 0 0; background: linear-gradient(90deg, var(--hex-grid) 1px, transparent 1px) 0 0, linear-gradient(180deg, var(--hex-grid) 1px, transparent 1px) 0 0; background-size: 40px 40px; background-color: var(--hex-concrete); position: relative; overflow: hidden; }
-        .page-header::before { content: "FIG. 08 — MACBOOK REPAIR MANUAL"; position: absolute; top: 80px; left: 20px; font-family: monospace; font-size: 0.7rem; color: var(--hex-black); opacity: 0.6; }
+        .page-header::before { content: "FIG. 12 — DATA RECOVERY PROTOCOL"; position: absolute; top: 80px; left: 20px; font-family: monospace; font-size: 0.7rem; color: var(--hex-black); opacity: 0.6; }
         .page-header-content { max-width: 1400px; margin: 0 auto; padding: 4rem 20px; position: relative; z-index: 2; }
         .page-header-box { text-align: center; border: 2px solid var(--hex-black); padding: 3rem 4rem; background: var(--hex-white); box-shadow: 15px 15px 0px var(--hex-black); }
         .page-title { font-size: clamp(2rem, 6vw, 4rem); font-weight: 900; line-height: 0.9; text-transform: uppercase; letter-spacing: -2px; color: var(--hex-black); margin-bottom: 1rem; }
         .page-title span { background: var(--gradient-blue); -webkit-background-clip: text; -webkit-text-fill-color: transparent; display: inline-block; }
         .page-subtitle { font-family: 'Courier New', Courier, monospace; font-size: clamp(0.9rem, 2vw, 1.1rem); text-transform: uppercase; background: var(--hex-black); color: var(--hex-white); display: inline-block; padding: 5px 8px; }
 
-        /* MODELS WE REPAIR */
+        /* DEVICES WE RECOVER */
         .models-section { padding: 0; border-top: 2px solid var(--hex-black); background: var(--hex-white); overflow: hidden; }
         .models-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0; border: 2px solid var(--hex-black); }
         .model-item { padding: 2rem 1.5rem; text-align: center; border-right: 2px solid var(--hex-black); position: relative; transition: all 0.2s; }
         .model-item:last-child { border-right: none; }
-        .model-item::before { content: "MODEL"; font-family: monospace; font-size: 0.6rem; position: absolute; top: 8px; right: 8px; color: #ccc; }
+        .model-item::before { content: "DEVICE"; font-family: monospace; font-size: 0.6rem; position: absolute; top: 8px; right: 8px; color: #ccc; }
         @media (hover: hover) {
             .model-item:hover { background: var(--hazard-stripe); }
             .model-item:hover .model-icon, .model-item:hover .model-name, .model-item:hover .model-years { background: var(--hex-white); color: var(--hex-black); box-shadow: 4px 4px 0 var(--hex-black); padding: 4px 8px; display: inline-block; position: relative; z-index: 2; }
@@ -423,7 +423,7 @@
             .section-subtitle { margin-bottom: 1.5rem; font-size: 0.8rem; }
             .container { padding: 0 12px; }
 
-            /* MODELS — 2-col compact grid */
+            /* DEVICES — 2-col compact grid */
             .models-grid { display: grid; grid-template-columns: repeat(2, 1fr); border: 2px solid var(--hex-black); }
             .model-item { min-width: unset; border-right: 2px solid var(--hex-black); border-bottom: 2px solid var(--hex-black); padding: 1.2rem 0.75rem; }
             .model-item:nth-child(2n) { border-right: none; }
@@ -540,192 +540,190 @@
     <header class="page-header">
         <div class="page-header-content">
             <div class="page-header-box fade-in">
-                <h1 class="page-title">MACBOOK <span>REPAIR</span> GUILDFORD</h1>
-                <p class="page-subtitle">Same-Day MacBook Pro &amp; Air Repair // No Fix, No Fee // 90-Day Warranty</p>
+                <h1 class="page-title">DATA <span>RECOVERY</span> GUILDFORD</h1>
+                <p class="page-subtitle">Professional Hard Drive, SSD &amp; Device Data Recovery // No Data, No Fee // Confidential</p>
             </div>
         </div>
     </header>
 
     <main id="main">
-        <!-- Models We Repair -->
+        <!-- Devices We Recover -->
         <section class="models-section" aria-labelledby="models-heading">
             <div class="container">
-                <h2 class="section-title fade-in" id="models-heading">"MODELS WE REPAIR"</h2>
-                <p class="section-subtitle fade-in">Every MacBook Generation Supported</p>
-                <div class="scroll-hint" aria-hidden="true">SCROLL &rarr;</div>
+                <h2 class="section-title fade-in" id="models-heading">"DEVICES WE RECOVER"</h2>
+                <p class="section-subtitle fade-in">Every Storage Device Supported</p>
                 <div class="models-grid">
                     <div class="model-item fade-in">
-                        <div class="model-icon"><i class="fas fa-laptop" aria-hidden="true"></i></div>
-                        <div class="model-name">MacBook Pro</div>
-                        <div class="model-years">2012 &ndash; 2024 (Intel &amp; M-Series)</div>
+                        <div class="model-icon"><i class="fas fa-hdd" aria-hidden="true"></i></div>
+                        <div class="model-name">Hard Drives (HDD)</div>
+                        <div class="model-years">Internal &amp; External</div>
                     </div>
                     <div class="model-item fade-in">
-                        <div class="model-icon"><i class="fas fa-laptop" aria-hidden="true"></i></div>
-                        <div class="model-name">MacBook Air</div>
-                        <div class="model-years">2013 &ndash; 2024 (Intel &amp; M-Series)</div>
+                        <div class="model-icon"><i class="fas fa-microchip" aria-hidden="true"></i></div>
+                        <div class="model-name">Solid State Drives (SSD)</div>
+                        <div class="model-years">SATA &amp; NVMe</div>
                     </div>
                     <div class="model-item fade-in">
-                        <div class="model-icon"><i class="fas fa-laptop" aria-hidden="true"></i></div>
-                        <div class="model-name">MacBook 12&quot;</div>
-                        <div class="model-years">2015 &ndash; 2017 (Retina)</div>
+                        <div class="model-icon"><i class="fab fa-usb" aria-hidden="true"></i></div>
+                        <div class="model-name">USB &amp; Memory Cards</div>
+                        <div class="model-years">Flash Drives, SD Cards</div>
                     </div>
                     <div class="model-item fade-in">
-                        <div class="model-icon"><i class="fas fa-desktop" aria-hidden="true"></i></div>
-                        <div class="model-name">iMac / Mac Mini</div>
-                        <div class="model-years">Select Models Supported</div>
+                        <div class="model-icon"><i class="fas fa-mobile-alt" aria-hidden="true"></i></div>
+                        <div class="model-name">Phone &amp; Laptop Storage</div>
+                        <div class="model-years">iPhone, Android, MacBook</div>
                     </div>
                 </div>
             </div>
         </section>
 
-        <!-- Common Issues -->
+        <!-- Recovery Services -->
         <section class="issues-section" aria-labelledby="issues-heading">
             <div class="container">
-                <h2 class="section-title fade-in" id="issues-heading">"COMMON ISSUES WE FIX"</h2>
-                <p class="section-subtitle fade-in">Board-Level Micro-Soldering &amp; Component Repair</p>
-                <div class="scroll-hint" aria-hidden="true">SCROLL &rarr;</div>
+                <h2 class="section-title fade-in" id="issues-heading">"DATA RECOVERY SERVICES"</h2>
+                <p class="section-subtitle fade-in">Professional Diagnosis &amp; Confidential Recovery</p>
                 <div class="issues-grid">
-                    <!-- LOGIC BOARD REPAIR -->
-                    <article class="issue-card fade-in" data-issue-num="ISSUE_01">
+                    <!-- ACCIDENTAL DELETION -->
+                    <article class="issue-card fade-in" data-issue-num="CASE_01">
+                        <div class="issue-header">
+                            <div class="issue-icon"><i class="fas fa-trash-restore" aria-hidden="true"></i></div>
+                            <h3 class="issue-title">Accidental Deletion Recovery</h3>
+                        </div>
+                        <p class="issue-description">Accidentally deleted important files, emptied the recycle bin, or formatted the wrong drive? In most cases your data is still physically present on the storage media until it is overwritten. We use specialist forensic tools to scan your drive sector-by-sector and recover deleted documents, photos, videos, and databases — even after a full format.</p>
+                        <p class="issue-subtitle">Common Scenarios:</p>
+                        <ul class="issue-symptoms">
+                            <li>Files permanently deleted from recycle bin</li>
+                            <li>Accidentally formatted hard drive or USB</li>
+                            <li>Lost files after Windows reinstallation</li>
+                            <li>Partition accidentally deleted or corrupted</li>
+                            <li>Overwritten files or lost folder structures</li>
+                        </ul>
+                        <div class="issue-bottom">
+                            <div class="issue-pricing">
+                                <div class="price-text">Starting From</div>
+                                <div class="issue-price">&pound;45</div>
+                            </div>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Recovery</a>
+                        </div>
+                    </article>
+
+                    <!-- HARD DRIVE FAILURE -->
+                    <article class="issue-card fade-in" data-issue-num="CASE_02">
+                        <div class="issue-header">
+                            <div class="issue-icon"><i class="fas fa-exclamation-triangle" aria-hidden="true"></i></div>
+                            <h3 class="issue-title">Hard Drive Failure</h3>
+                        </div>
+                        <p class="issue-description">Mechanical hard drives contain precision moving parts that can fail without warning. Clicking, grinding, or beeping noises indicate a head crash or motor failure. We recover data from drives that are no longer detected by your computer, have suffered head crashes, or show signs of platter damage — using specialist imaging tools designed for degraded media.</p>
+                        <p class="issue-subtitle">Common Scenarios:</p>
+                        <ul class="issue-symptoms">
+                            <li>Drive making clicking or grinding noises</li>
+                            <li>Hard drive not spinning up at all</li>
+                            <li>Drive not detected in BIOS or Disk Management</li>
+                            <li>Extremely slow read speeds or freezing</li>
+                            <li>Bad sectors causing file access errors</li>
+                        </ul>
+                        <div class="issue-bottom">
+                            <div class="issue-pricing">
+                                <div class="price-text">Starting From</div>
+                                <div class="issue-price">&pound;55</div>
+                            </div>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Recovery</a>
+                        </div>
+                    </article>
+
+                    <!-- SSD DATA RECOVERY -->
+                    <article class="issue-card fade-in" data-issue-num="CASE_03">
                         <div class="issue-header">
                             <div class="issue-icon"><i class="fas fa-microchip" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">Logic Board Repair</h3>
+                            <h3 class="issue-title">SSD Data Recovery</h3>
                         </div>
-                        <p class="issue-description">The logic board is the brain of your MacBook. Failed power ICs, blown capacitors, GPU faults, and short circuits can all cause a dead or malfunctioning machine. We perform board-level micro-soldering to diagnose and replace the specific failed components — saving your MacBook when Apple says it needs a full replacement.</p>
-                        <p class="issue-subtitle">Symptoms:</p>
+                        <p class="issue-description">SSDs fail differently to traditional hard drives — there are no moving parts, but controller failures, firmware corruption, and NAND flash degradation can make your data inaccessible overnight. We use chip-level reading tools and firmware-patching techniques to recover data from dead SSDs, including SATA, NVMe, and M.2 form factors.</p>
+                        <p class="issue-subtitle">Common Scenarios:</p>
                         <ul class="issue-symptoms">
-                            <li>MacBook completely dead — no power, no light</li>
-                            <li>Turns on but no display (backlight failure)</li>
-                            <li>Random kernel panics and crashes</li>
-                            <li>USB-C / Thunderbolt ports not working</li>
-                            <li>Fan spinning at full speed constantly</li>
+                            <li>SSD suddenly not detected by computer</li>
+                            <li>Drive appears as wrong size (e.g. 0MB or 8MB)</li>
+                            <li>Firmware corruption preventing boot</li>
+                            <li>TRIM-related data loss after deletion</li>
+                            <li>SSD read-only mode or write protection</li>
                         </ul>
                         <div class="issue-bottom">
                             <div class="issue-pricing">
                                 <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;95</div>
+                                <div class="issue-price">&pound;65</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Board Repair</a>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Recovery</a>
                         </div>
                     </article>
 
-                    <!-- SCREEN REPLACEMENT -->
-                    <article class="issue-card fade-in" data-issue-num="ISSUE_02">
-                        <div class="issue-header">
-                            <div class="issue-icon"><i class="fas fa-desktop" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">Screen Replacement</h3>
-                        </div>
-                        <p class="issue-description">Cracked glass, dead pixels, vertical lines, or a completely black display — we replace MacBook screens with quality Retina-grade panels. Whether it's a MacBook Pro 13&quot;, 14&quot;, 15&quot;, or 16&quot;, or a MacBook Air, we have screens in stock for most models and complete the swap with precise calibration.</p>
-                        <p class="issue-subtitle">Symptoms:</p>
-                        <ul class="issue-symptoms">
-                            <li>Cracked or shattered display glass</li>
-                            <li>Vertical coloured lines across the screen</li>
-                            <li>Black screen but MacBook sounds on</li>
-                            <li>Flickering or dim display</li>
-                            <li>Dead pixels or discoloured patches</li>
-                        </ul>
-                        <div class="issue-bottom">
-                            <div class="issue-pricing">
-                                <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;149</div>
-                            </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Screen Repair</a>
-                        </div>
-                    </article>
-
-                    <!-- BATTERY REPLACEMENT -->
-                    <article class="issue-card fade-in" data-issue-num="ISSUE_03">
-                        <div class="issue-header">
-                            <div class="issue-icon"><i class="fas fa-battery-quarter" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">Battery Replacement</h3>
-                        </div>
-                        <p class="issue-description">MacBook batteries degrade over time — after 500-1000 charge cycles, capacity drops significantly. Swollen batteries are a safety hazard that can warp the trackpad or case. We replace batteries with high-quality cells that restore your MacBook to full-day battery life. Most battery swaps are completed same-day.</p>
-                        <p class="issue-subtitle">Symptoms:</p>
-                        <ul class="issue-symptoms">
-                            <li>"Service Battery" or "Replace Soon" warning</li>
-                            <li>Battery drains in under 2 hours</li>
-                            <li>Swollen/bulging trackpad or bottom case</li>
-                            <li>MacBook only works when plugged in</li>
-                            <li>Random shutdowns at 20-40% battery</li>
-                        </ul>
-                        <div class="issue-bottom">
-                            <div class="issue-pricing">
-                                <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;79</div>
-                            </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Battery Swap</a>
-                        </div>
-                    </article>
-
-                    <!-- KEYBOARD REPAIR -->
-                    <article class="issue-card fade-in" data-issue-num="ISSUE_04">
-                        <div class="issue-header">
-                            <div class="issue-icon"><i class="fas fa-keyboard" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">Keyboard Repair</h3>
-                        </div>
-                        <p class="issue-description">The infamous butterfly keyboard (2016-2019 MacBook Pro) is notorious for stuck and unresponsive keys. Even scissor-switch keyboards on newer models can fail from dust or liquid ingress. We replace faulty keyboards — including full top case swaps when needed — restoring every key to reliable operation.</p>
-                        <p class="issue-subtitle">Symptoms:</p>
-                        <ul class="issue-symptoms">
-                            <li>Keys stuck, mushy, or unresponsive</li>
-                            <li>Double-typing or ghost key presses</li>
-                            <li>Backlight not working on some keys</li>
-                            <li>Spacebar or shift key intermittent</li>
-                            <li>Keys physically missing or broken</li>
-                        </ul>
-                        <div class="issue-bottom">
-                            <div class="issue-pricing">
-                                <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;89</div>
-                            </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Keyboard Fix</a>
-                        </div>
-                    </article>
-
-                    <!-- SSD UPGRADE & DATA RECOVERY -->
-                    <article class="issue-card fade-in" data-issue-num="ISSUE_05">
-                        <div class="issue-header">
-                            <div class="issue-icon"><i class="fas fa-hdd" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">SSD Upgrade &amp; Data Recovery</h3>
-                        </div>
-                        <p class="issue-description">Running out of storage or stuck on a slow spinning hard drive? We upgrade older MacBooks to fast NVMe SSDs — making them feel like new machines. For failing drives, we recover your data before it's lost. We handle everything from 128GB to 2TB upgrades, including OS migration so you're back up and running immediately.</p>
-                        <p class="issue-subtitle">Symptoms:</p>
-                        <ul class="issue-symptoms">
-                            <li>"Startup disk almost full" warnings</li>
-                            <li>Extremely slow boot times (spinning wheel)</li>
-                            <li>Apps freezing or beach-balling constantly</li>
-                            <li>Clicking noises from hard drive</li>
-                            <li>Files disappearing or corrupted</li>
-                        </ul>
-                        <div class="issue-bottom">
-                            <div class="issue-pricing">
-                                <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;69</div>
-                            </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book SSD Upgrade</a>
-                        </div>
-                    </article>
-
-                    <!-- WATER DAMAGE -->
-                    <article class="issue-card fade-in" data-issue-num="ISSUE_06">
+                    <!-- WATER & FIRE DAMAGE -->
+                    <article class="issue-card fade-in" data-issue-num="CASE_04">
                         <div class="issue-header">
                             <div class="issue-icon"><i class="fas fa-tint" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">Water Damage Repair</h3>
+                            <h3 class="issue-title">Water &amp; Fire Damage Recovery</h3>
                         </div>
-                        <p class="issue-description">Spilled coffee, tea, or water on your MacBook? Time is critical. Liquid causes corrosion that spreads across the logic board within hours. We perform ultrasonic cleaning to remove all corrosion, then diagnose and replace any damaged components using micro-soldering. The sooner you bring it in, the better the recovery chances.</p>
-                        <p class="issue-subtitle">Symptoms:</p>
+                        <p class="issue-description">Floods, burst pipes, spilled drinks, or house fires can devastate your storage devices — but the data inside is often recoverable. We carefully clean and dry affected components, repair corroded circuitry, and image the storage media before any further degradation occurs. Even drives submerged in water or exposed to extreme heat can yield recoverable data.</p>
+                        <p class="issue-subtitle">Common Scenarios:</p>
                         <ul class="issue-symptoms">
-                            <li>MacBook dead after liquid spill</li>
-                            <li>Keyboard keys sticking or not working</li>
-                            <li>Trackpad clicking on its own</li>
-                            <li>Screen flickering or discoloured</li>
-                            <li>Charging intermittent or not working</li>
+                            <li>Hard drive or laptop submerged in water</li>
+                            <li>Flood-damaged external drives or NAS</li>
+                            <li>Coffee or liquid spill on laptop</li>
+                            <li>Smoke or heat damage from fire</li>
+                            <li>Corroded connectors or circuit boards</li>
+                        </ul>
+                        <div class="issue-bottom">
+                            <div class="issue-pricing">
+                                <div class="price-text">Starting From</div>
+                                <div class="issue-price">&pound;75</div>
+                            </div>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Recovery</a>
+                        </div>
+                    </article>
+
+                    <!-- PHONE DATA RECOVERY -->
+                    <article class="issue-card fade-in" data-issue-num="CASE_05">
+                        <div class="issue-header">
+                            <div class="issue-icon"><i class="fas fa-mobile-alt" aria-hidden="true"></i></div>
+                            <h3 class="issue-title">Phone Data Recovery</h3>
+                        </div>
+                        <p class="issue-description">Your phone holds irreplaceable photos, messages, contacts, and documents. When your phone is dead, has a smashed screen, or has suffered water damage, accessing that data can feel impossible. We recover data from iPhones and Android devices by repairing the device just enough to extract your files — even when the phone itself is beyond economic repair.</p>
+                        <p class="issue-subtitle">Common Scenarios:</p>
+                        <ul class="issue-symptoms">
+                            <li>Phone completely dead and won't power on</li>
+                            <li>Smashed screen with no display output</li>
+                            <li>Water-damaged phone not responding</li>
+                            <li>Phone stuck in boot loop or bricked</li>
+                            <li>Need data from old or broken handset</li>
+                        </ul>
+                        <div class="issue-bottom">
+                            <div class="issue-pricing">
+                                <div class="price-text">Starting From</div>
+                                <div class="issue-price">&pound;45</div>
+                            </div>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Recovery</a>
+                        </div>
+                    </article>
+
+                    <!-- RAID & SERVER RECOVERY -->
+                    <article class="issue-card fade-in" data-issue-num="CASE_06">
+                        <div class="issue-header">
+                            <div class="issue-icon"><i class="fas fa-server" aria-hidden="true"></i></div>
+                            <h3 class="issue-title">RAID &amp; Server Recovery</h3>
+                        </div>
+                        <p class="issue-description">RAID arrays and NAS devices are designed for redundancy — but multiple drive failures, controller malfunctions, or failed rebuilds can bring the entire array down. We recover data from RAID 0, 1, 5, 6, and 10 configurations, including Synology, QNAP, and custom server setups. We rebuild the array virtually and extract your data without risking further damage.</p>
+                        <p class="issue-subtitle">Common Scenarios:</p>
+                        <ul class="issue-symptoms">
+                            <li>Multiple drives failed in RAID array</li>
+                            <li>RAID rebuild failed or interrupted</li>
+                            <li>NAS device not booting or inaccessible</li>
+                            <li>RAID controller failure or corruption</li>
+                            <li>Accidental RAID reconfiguration or initialisation</li>
                         </ul>
                         <div class="issue-bottom">
                             <div class="issue-pricing">
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;85</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Water Damage Repair</a>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Recovery</a>
                         </div>
                     </article>
                 </div>
@@ -733,10 +731,10 @@
         </section>
 
         <!-- Emergency CTA -->
-        <section class="emergency-section" aria-label="Emergency repair contact">
+        <section class="emergency-section" aria-label="Emergency data recovery contact">
             <div class="container">
-                <h2>"MACBOOK DOWN?"</h2>
-                <p>Don't replace it — repair it. Same-day service available. Free diagnosis. No fix, no fee. Call to book a drop-off.</p>
+                <h2>"LOST IMPORTANT DATA?"</h2>
+                <p>Don't risk making it worse. Stop using the device and call us. No data, no fee. Fully confidential. Call to book a drop-off.</p>
                 <a href="tel:+447940730537" class="emergency-btn">
                     <i class="fas fa-phone-alt" aria-hidden="true"></i> Call to Book — 07940 730537
                 </a>
@@ -747,39 +745,39 @@
         <section class="why-section" aria-labelledby="why-heading">
             <div class="container">
                 <h2 class="section-title fade-in" id="why-heading">"WHY CHOOSE ONLINEFIX?"</h2>
-                <p class="section-subtitle fade-in">Board-Level Repair. Not Just Part Swapping.</p>
+                <p class="section-subtitle fade-in">Trusted, Confidential, Professional Data Recovery</p>
                 <div class="why-grid">
                     <div class="why-item fade-in">
                         <div class="why-icon"><i class="fas fa-shield-alt" aria-hidden="true"></i></div>
-                        <div class="why-title">No Fix, No Fee</div>
-                        <p class="why-description">If we can't repair your MacBook, you don't pay a penny. Zero risk — we only charge for successful repairs.</p>
+                        <div class="why-title">No Data, No Fee</div>
+                        <p class="why-description">If we cannot recover your data, you do not pay. Zero risk — we only charge when your files are successfully retrieved.</p>
+                    </div>
+                    <div class="why-item fade-in">
+                        <div class="why-icon"><i class="fas fa-lock" aria-hidden="true"></i></div>
+                        <div class="why-title">Confidential Service</div>
+                        <p class="why-description">Your data is handled on secure, isolated systems. We never browse or copy your files. All working copies are securely wiped after collection.</p>
                     </div>
                     <div class="why-item fade-in">
                         <div class="why-icon"><i class="fas fa-bolt" aria-hidden="true"></i></div>
-                        <div class="why-title">Same-Day Repairs</div>
-                        <p class="why-description">Battery swaps and SSD upgrades done same-day. Unlike Apple Store who quote 5-7 business days, we repair on-site in Guildford.</p>
+                        <div class="why-title">24hr Priority Option</div>
+                        <p class="why-description">Need your data urgently? Our priority service fast-tracks your recovery. Contact us and we will assess turnaround based on the case complexity.</p>
                     </div>
                     <div class="why-item fade-in">
-                        <div class="why-icon"><i class="fas fa-certificate" aria-hidden="true"></i></div>
-                        <div class="why-title">90-Day Warranty</div>
-                        <p class="why-description">Every repair backed by our 90-day warranty. If the same fault returns within 90 days, we fix it again completely free.</p>
-                    </div>
-                    <div class="why-item fade-in">
-                        <div class="why-icon"><i class="fas fa-microchip" aria-hidden="true"></i></div>
-                        <div class="why-title">Board-Level Repair</div>
-                        <p class="why-description">We micro-solder individual components — saving your MacBook when Apple says "replace the whole board" for &pound;500+.</p>
+                        <div class="why-icon"><i class="fas fa-calendar-check" aria-hidden="true"></i></div>
+                        <div class="why-title">Easy Scheduled Drop-Off</div>
+                        <p class="why-description">Book a convenient drop-off time at our Guildford workshop. Open 10am&ndash;10pm, 7 days a week. Serving Woking, Godalming &amp; Farnham too.</p>
                     </div>
                 </div>
                 <div class="why-vs fade-in">
-                    <div class="why-vs-title">OnlineFix vs. Apple Store &amp; Others</div>
+                    <div class="why-vs-title">OnlineFix vs. National Recovery Companies</div>
                     <div class="why-vs-row">
                         <div class="why-vs-col">
                             <div class="why-vs-label">OnlineFix</div>
-                            <div class="why-vs-value highlight">Board-level repair from &pound;79<br>Same-day for most repairs<br>No fix, no fee<br>90-day warranty<br>Easy scheduled drop-offs</div>
+                            <div class="why-vs-value highlight">Recovery from &pound;45<br>Local Guildford service<br>No data, no fee<br>Fully confidential<br>Easy scheduled drop-offs</div>
                         </div>
                         <div class="why-vs-col">
-                            <div class="why-vs-label">Apple Store / Others</div>
-                            <div class="why-vs-value">"Replace entire board" from &pound;500+<br>5-7 business days minimum<br>Diagnostic fees charged upfront<br>Limited warranty on parts only<br>Long wait for appointments</div>
+                            <div class="why-vs-label">National Recovery Companies</div>
+                            <div class="why-vs-value">Recovery from &pound;300+<br>Ship your drive to a lab<br>Diagnostic fees charged upfront<br>Your data leaves your area<br>Weeks-long turnaround times</div>
                         </div>
                     </div>
                 </div>
@@ -790,27 +788,27 @@
         <section class="process-section" aria-labelledby="process-heading">
             <div class="container">
                 <h2 class="section-title fade-in" id="process-heading">"HOW IT WORKS"</h2>
-                <p class="section-subtitle fade-in">Drop Off &rarr; Diagnose &rarr; Repair &rarr; Collect</p>
+                <p class="section-subtitle fade-in">Book &rarr; Drop Off &rarr; Diagnose &amp; Recover &rarr; Verified &amp; Returned</p>
                 <div class="process-grid">
                     <div class="process-item fade-in">
                         <div class="process-number">01</div>
-                        <h4>Free Diagnosis</h4>
-                        <p>Call us or describe the issue over the phone. Book a drop-off and we diagnose the fault at no cost — including board-level testing.</p>
+                        <h4>Book Your Drop-Off</h4>
+                        <p>Call us or send a message describing what happened. We will book a convenient drop-off time and advise you on how to safely handle the device until then.</p>
                     </div>
                     <div class="process-item fade-in">
                         <div class="process-number">02</div>
-                        <h4>Transparent Quote</h4>
-                        <p>You get a clear price before we start. No hidden fees, no surprises. We explain exactly what's wrong and what the fix involves.</p>
+                        <h4>Drop Off Your Device</h4>
+                        <p>Bring your device to our Guildford workshop at your booked time. We perform an initial assessment and provide a fixed quote before any recovery work begins.</p>
                     </div>
                     <div class="process-item fade-in">
                         <div class="process-number">03</div>
-                        <h4>Expert Repair</h4>
-                        <p>Professional micro-soldering and component-level repair using quality parts. Your data stays safe throughout — we never wipe without asking.</p>
+                        <h4>Diagnose &amp; Recover</h4>
+                        <p>We image your storage media using specialist tools, then extract and reconstruct your files. Your data is handled on secure, isolated systems throughout.</p>
                     </div>
                     <div class="process-item fade-in">
                         <div class="process-number">04</div>
-                        <h4>Tested &amp; Returned</h4>
-                        <p>Every repair is stress-tested with diagnostics before collection. Your MacBook comes back working perfectly, with a 90-day warranty.</p>
+                        <h4>Verified &amp; Returned</h4>
+                        <p>We provide a file listing so you can verify your recovered data. Once confirmed, your files are returned on a clean drive or USB. All working copies are securely wiped.</p>
                     </div>
                 </div>
             </div>
@@ -820,42 +818,42 @@
         <section class="faq-section" aria-labelledby="faq-heading">
             <div class="container">
                 <h2 class="section-title fade-in" id="faq-heading">"FAQ"</h2>
-                <p class="section-subtitle fade-in">Common Questions About MacBook Repair</p>
+                <p class="section-subtitle fade-in">Common Questions About Data Recovery</p>
                 <div class="faq-list">
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">How much does a MacBook screen replacement cost in Guildford?</button>
+                        <button class="faq-question" aria-expanded="false">What is the success rate for data recovery?</button>
                         <div class="faq-answer" role="region">
-                            <p>MacBook screen replacement at OnlineFix Guildford starts from &pound;149 depending on the model. MacBook Air screens are typically less expensive than MacBook Pro Retina displays. The price includes the replacement display, professional fitting, and full testing. We operate a <strong>no fix, no fee</strong> policy and all repairs include a <strong>90-day warranty</strong>.</p>
+                            <p>Our data recovery success rate is approximately <strong>90% across all device types</strong>. Logical failures such as accidental deletion and formatting have the highest recovery rates, often close to 100%. Mechanical hard drive failures and water-damaged devices have slightly lower rates depending on the severity. We operate a <strong>no data, no fee</strong> policy — if we cannot recover your data, you do not pay.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">Can you fix a MacBook that won't turn on?</button>
+                        <button class="faq-question" aria-expanded="false">How much does data recovery cost in Guildford?</button>
                         <div class="faq-answer" role="region">
-                            <p>Yes. A MacBook that won't turn on is usually caused by a faulty logic board, failed power IC, liquid damage, or a dead battery. At OnlineFix Guildford, we diagnose the exact cause with board-level testing equipment and only charge for the specific repair needed. Our <strong>no fix, no fee</strong> policy means you won't pay if we can't resolve it, and all repairs include a <strong>90-day warranty</strong>. Most power-related MacBook repairs are completed within <strong>24-48 hours</strong>.</p>
+                            <p>Data recovery at OnlineFix Guildford starts from <strong>&pound;45</strong> for straightforward deleted file recovery. Hard drive failure recovery starts from &pound;55, SSD recovery from &pound;65, and RAID or server recovery from &pound;85. We provide a <strong>fixed quote after diagnosis</strong> before any work begins. No data, no fee — you only pay if we successfully recover your files.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">Do you repair water-damaged MacBooks?</button>
+                        <button class="faq-question" aria-expanded="false">How long does data recovery take?</button>
                         <div class="faq-answer" role="region">
-                            <p>Yes, we specialise in MacBook liquid damage repair. We perform ultrasonic cleaning of the logic board, replace corroded components using micro-soldering, and restore full functionality. The sooner you bring it in after a spill, the better the chances. <strong>No fix, no fee</strong> — if we can't save it, you don't pay. <strong>Call to book your drop-off</strong> at our Guildford shop.</p>
+                            <p>Simple deleted file recovery can often be completed within <strong>24 hours</strong>. Hard drive and SSD recovery typically takes 2-5 working days depending on the severity of the failure. RAID and server recovery may take up to 7 working days. We offer a <strong>24-hour priority service</strong> for urgent cases. You will receive a time estimate when you <strong>book your drop-off</strong>.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">How long does a MacBook repair take?</button>
+                        <button class="faq-question" aria-expanded="false">Is my data kept confidential during recovery?</button>
                         <div class="faq-answer" role="region">
-                            <p>Most MacBook repairs are completed <strong>same-day or within 1-3 days</strong>. Battery swaps and SSD upgrades are typically same-day. Screen replacements and keyboard repairs take 24-48 hours. Logic board repairs may take 2-3 days for thorough testing. Unlike the Apple Store who quote 5-7 business days, we repair on-site in Guildford. Serving Guildford, Woking, Godalming, and Farnham.</p>
+                            <p>Absolutely. <strong>Confidentiality is central</strong> to our data recovery service. We never browse, copy, or share your recovered files. Your data is handled on secure, isolated systems. Once recovery is complete and you have verified your files, all working copies are <strong>securely wiped</strong> from our systems. We are happy to sign a non-disclosure agreement if required.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">Is it worth repairing an old MacBook?</button>
+                        <button class="faq-question" aria-expanded="false">What devices can you recover data from?</button>
                         <div class="faq-answer" role="region">
-                            <p>Often yes. An SSD upgrade and battery replacement can make a 2015-2019 MacBook feel brand new for a fraction of the cost of a replacement. We provide honest advice — if a repair doesn't make economic sense, we'll tell you upfront during our <strong>free diagnosis</strong>. <strong>No fix, no fee</strong> means zero risk to you.</p>
+                            <p>We recover data from virtually <strong>all storage devices</strong> including internal and external hard drives (HDD), solid state drives (SSD, NVMe, M.2), USB flash drives, SD cards, microSD cards, iPhones, Android phones, laptops, MacBooks, RAID arrays, and NAS devices. If your data was stored on it, we can almost certainly attempt recovery. <strong>Call to book your drop-off</strong> at our Guildford workshop.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">Is there a warranty on MacBook repairs?</button>
+                        <button class="faq-question" aria-expanded="false">Should I attempt recovery myself before bringing it in?</button>
                         <div class="faq-answer" role="region">
-                            <p>Yes, every MacBook repair at OnlineFix comes with a <strong>90-day warranty</strong> as standard. We stand behind every repair and use quality replacement components. If the same issue recurs within the warranty period, we'll fix it at no additional cost. We also operate a <strong>no fix, no fee</strong> policy — unlike the Apple Store, there's no diagnostic fee and no risk to you.</p>
+                            <p>We <strong>strongly recommend against DIY recovery attempts</strong>. Running a failed hard drive, installing recovery software on the affected drive, or opening a drive outside a clean environment can permanently destroy data. The best course of action is to <strong>power off the device immediately</strong> and book a drop-off with us. The less the device is used after data loss, the higher the chance of successful recovery.</p>
                         </div>
                     </div>
                 </div>
@@ -865,13 +863,13 @@
         <section style="padding: 3rem 0; border-top: 2px solid var(--hex-black); background: var(--hex-concrete);" aria-label="Other repair services">
             <div class="container">
                 <h2 style="font-size: clamp(1.3rem, 3vw, 1.8rem); font-weight: 900; text-transform: uppercase; text-align: center; margin-bottom: 0.5rem;">"OTHER SERVICES"</h2>
-                <p style="text-align: center; font-family: monospace; color: #666; font-size: 0.85rem; margin-bottom: 2rem; text-transform: uppercase;">We repair more than just MacBooks</p>
+                <p style="text-align: center; font-family: monospace; color: #666; font-size: 0.85rem; margin-bottom: 2rem; text-transform: uppercase;">We do more than just data recovery</p>
                 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; max-width: 900px; margin: 0 auto;">
                     <a href="iphone-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-mobile-alt" aria-hidden="true" style="color: var(--hex-accent);"></i> iPhone Repair</a>
                     <a href="console-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-gamepad" aria-hidden="true" style="color: var(--hex-accent);"></i> Console Repair</a>
+                    <a href="macbook-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-laptop" aria-hidden="true" style="color: var(--hex-accent);"></i> MacBook Repair</a>
                     <a href="tablet-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-tablet-alt" aria-hidden="true" style="color: var(--hex-accent);"></i> Tablet Repair</a>
                     <a href="pc-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-desktop" aria-hidden="true" style="color: var(--hex-accent);"></i> PC Repair</a>
-                    <a href="data-recovery.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-hdd" aria-hidden="true" style="color: var(--hex-accent);"></i> Data Recovery</a>
                 </div>
             </div>
         </section>
@@ -883,7 +881,7 @@
             <div class="footer-grid">
                 <div class="footer-column">
                     <h4>"ONLINEFIX"</h4>
-                    <p style="font-family: monospace; color: #999;">Expert electronics &amp; MacBook repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
+                    <p style="font-family: monospace; color: #999;">Expert data recovery &amp; device repair in Guildford. Trusted, confidential, and reliable service by Tomas.</p>
                     <div class="social-links" style="margin-top: 1rem; font-size: 1.5rem;">
                         <a href="https://instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
                         <a href="https://tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
@@ -983,24 +981,6 @@
             el.style.animationPlayState = 'paused';
             fadeObserver.observe(el);
         });
-
-        // Mobile scroll nudge
-        if (window.innerWidth < 768) {
-            const scrollGrids = document.querySelectorAll('.issues-grid, .models-grid');
-            const nudgeObserver = new IntersectionObserver((entries) => {
-                entries.forEach(entry => {
-                    if (entry.isIntersecting) {
-                        const target = entry.target;
-                        setTimeout(() => {
-                            target.scrollBy({ left: 50, behavior: 'smooth' });
-                            setTimeout(() => { target.scrollBy({ left: -50, behavior: 'smooth' }); }, 800);
-                        }, 500);
-                        nudgeObserver.unobserve(target);
-                    }
-                });
-            }, { threshold: 0.6 });
-            scrollGrids.forEach(grid => nudgeObserver.observe(grid));
-        }
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1304,6 +1304,21 @@
                         <h3 class="service-title">Consoles</h3>
                         <p>Professional <a href="console-repair.html" class="service-link">PlayStation and Xbox repair</a> including HDMI port reinforcement.</p>
                     </div>
+                    <div class="service-card fade-in" role="listitem">
+                        <div class="service-icon" aria-hidden="true"><i class="fas fa-tablet-alt"></i></div>
+                        <h3 class="service-title">Tablets</h3>
+                        <p>Expert <a href="tablet-repair.html" class="service-link">iPad and tablet repair</a>, screen replacement, and battery fixes.</p>
+                    </div>
+                    <div class="service-card fade-in" role="listitem">
+                        <div class="service-icon" aria-hidden="true"><i class="fas fa-desktop"></i></div>
+                        <h3 class="service-title">PCs</h3>
+                        <p>Complete <a href="pc-repair.html" class="service-link">desktop and gaming PC repair</a>, upgrades, and virus removal.</p>
+                    </div>
+                    <div class="service-card fade-in" role="listitem">
+                        <div class="service-icon" aria-hidden="true"><i class="fas fa-hdd"></i></div>
+                        <h3 class="service-title">Data Recovery</h3>
+                        <p>Professional <a href="data-recovery.html" class="service-link">data recovery</a> from hard drives, SSDs, USB drives, and phones.</p>
+                    </div>
                 </div>
                 <div style="text-align: center; margin-top: 2rem;">
                     <a href="services.html" class="cta-button">
@@ -1418,6 +1433,9 @@
                         <li><a href="iphone-repair.html">iPhone Repair</a></li>
                         <li><a href="console-repair.html">Console Repair</a></li>
                         <li><a href="macbook-repair.html">MacBook Repair</a></li>
+                        <li><a href="tablet-repair.html">Tablet Repair</a></li>
+                        <li><a href="pc-repair.html">PC Repair</a></li>
+                        <li><a href="data-recovery.html">Data Recovery</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>

--- a/iphone-repair.html
+++ b/iphone-repair.html
@@ -859,6 +859,20 @@
                 </div>
             </div>
         </section>
+        <!-- Other Services Cross-Links -->
+        <section style="padding: 3rem 0; border-top: 2px solid var(--hex-black); background: var(--hex-concrete);" aria-label="Other repair services">
+            <div class="container">
+                <h2 style="font-size: clamp(1.3rem, 3vw, 1.8rem); font-weight: 900; text-transform: uppercase; text-align: center; margin-bottom: 0.5rem;">"OTHER SERVICES"</h2>
+                <p style="text-align: center; font-family: monospace; color: #666; font-size: 0.85rem; margin-bottom: 2rem; text-transform: uppercase;">We repair more than just iPhones</p>
+                <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; max-width: 900px; margin: 0 auto;">
+                    <a href="console-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-gamepad" aria-hidden="true" style="color: var(--hex-accent);"></i> Console Repair</a>
+                    <a href="macbook-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-laptop" aria-hidden="true" style="color: var(--hex-accent);"></i> MacBook Repair</a>
+                    <a href="tablet-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-tablet-alt" aria-hidden="true" style="color: var(--hex-accent);"></i> Tablet Repair</a>
+                    <a href="pc-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-desktop" aria-hidden="true" style="color: var(--hex-accent);"></i> PC Repair</a>
+                    <a href="data-recovery.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-hdd" aria-hidden="true" style="color: var(--hex-accent);"></i> Data Recovery</a>
+                </div>
+            </div>
+        </section>
     </main>
 
     <!-- Footer -->
@@ -881,6 +895,9 @@
                         <li><a href="iphone-repair.html">iPhone Repair</a></li>
                         <li><a href="console-repair.html">Console Repair</a></li>
                         <li><a href="macbook-repair.html">MacBook Repair</a></li>
+                        <li><a href="tablet-repair.html">Tablet Repair</a></li>
+                        <li><a href="pc-repair.html">PC Repair</a></li>
+                        <li><a href="data-recovery.html">Data Recovery</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>

--- a/pc-repair.html
+++ b/pc-repair.html
@@ -11,13 +11,13 @@
     <!-- Security & Privacy -->
     <meta name="referrer" content="strict-origin-when-cross-origin">
 
-    <!-- SEO Meta Tags - MACBOOK REPAIR LANDING PAGE -->
-    <title>MacBook Repair Guildford | Logic Board &amp; Screen Fix Surrey | Same-Day | OnlineFix</title>
-    <meta name="description" content="Expert MacBook repair in Guildford, Surrey. Logic board repair, screen replacement, SSD upgrade, battery swap, keyboard fix. Same-day service — by appointment only. No fix, no fee. 90-day warranty. Call 07940 730537.">
-    <meta name="keywords" content="MacBook repair Guildford, MacBook screen replacement Surrey, MacBook logic board repair, MacBook battery replacement Guildford, MacBook Pro repair near me, MacBook Air repair Guildford, laptop repair Guildford, MacBook keyboard repair, MacBook SSD upgrade, MacBook not turning on, MacBook water damage repair, MacBook repair Woking, MacBook repair Godalming, MacBook repair Farnham, no fix no fee laptop repair">
+    <!-- SEO Meta Tags - PC REPAIR LANDING PAGE -->
+    <title>PC &amp; Desktop Repair Guildford | Hardware &amp; Software Fix Surrey | OnlineFix</title>
+    <meta name="description" content="Expert PC repair and desktop repair in Guildford, Surrey. Hardware diagnosis, virus removal, SSD upgrades, RAM upgrades, Windows installation. By appointment only — same-day service. No fix, no fee. 90-day warranty. Call 07940 730537.">
+    <meta name="keywords" content="PC repair Guildford, desktop repair Surrey, computer repair Guildford, gaming PC repair, PC not turning on Guildford, virus removal Guildford, SSD upgrade Surrey, RAM upgrade Guildford, Windows installation Guildford, PC overheating repair, desktop repair near me, PC repair Woking, PC repair Godalming, PC repair Farnham, no fix no fee PC repair, same day PC repair Guildford">
     <meta name="author" content="OnlineFix - Tomas">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
-    <link rel="canonical" href="https://onlinefix.co.uk/macbook-repair.html">
+    <link rel="canonical" href="https://onlinefix.co.uk/pc-repair.html">
     <link rel="sitemap" type="application/xml" href="/sitemap.xml">
 
     <!-- Local SEO Geo-Tags -->
@@ -28,20 +28,20 @@
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://onlinefix.co.uk/macbook-repair.html">
+    <meta property="og:url" content="https://onlinefix.co.uk/pc-repair.html">
     <meta property="og:site_name" content="OnlineFix Guildford">
-    <meta property="og:title" content="MacBook Repair Guildford | Logic Board & Screen Fix | No Fix No Fee">
-    <meta property="og:description" content="Broken MacBook? No fix, no fee. Expert MacBook Pro & Air repair in Guildford. Logic board, screen, battery, keyboard & SSD repairs. Same-day service. 90-day warranty.">
+    <meta property="og:title" content="PC & Desktop Repair Guildford | Hardware & Software Fix | No Fix No Fee">
+    <meta property="og:description" content="PC problems? No fix, no fee. Expert desktop &amp; gaming PC repair, virus removal, SSD upgrades, hardware diagnosis in Guildford. Same-day service. 90-day warranty.">
     <meta property="og:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="OnlineFix MacBook Repair - Logic Board Screen Battery Repair Guildford">
+    <meta property="og:image:alt" content="OnlineFix PC & Desktop Repair - Hardware Software Upgrades Guildford">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://onlinefix.co.uk/macbook-repair.html">
-    <meta property="twitter:title" content="MacBook Repair Guildford | Same-Day Fix | No Fix No Fee">
-    <meta property="twitter:description" content="MacBook Pro & Air repair in Guildford. Logic board, screen, battery, keyboard & SSD. Same-day service. 90-day warranty. Appointment only.">
+    <meta property="twitter:url" content="https://onlinefix.co.uk/pc-repair.html">
+    <meta property="twitter:title" content="PC & Desktop Repair Guildford | Same-Day Fix | No Fix No Fee">
+    <meta property="twitter:description" content="PC &amp; desktop hardware repair, virus removal, SSD &amp; RAM upgrades in Guildford. Same-day service. 90-day warranty. By appointment only.">
     <meta property="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
 
     <!-- Favicon -->
@@ -80,8 +80,8 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "MacBook Repair",
-                "item": "https://onlinefix.co.uk/macbook-repair.html"
+                "name": "PC Repair",
+                "item": "https://onlinefix.co.uk/pc-repair.html"
             }
         ]
     }
@@ -92,9 +92,9 @@
     {
         "@context": "https://schema.org",
         "@type": "WebPage",
-        "name": "MacBook Repair Guildford | Logic Board & Screen Fix Surrey",
-        "description": "No fix, no fee MacBook repair in Guildford, Surrey. Same-day MacBook Pro and MacBook Air repair. Logic board repair, screen replacement, SSD upgrade, battery swap, keyboard fix, water damage recovery. 90-day warranty. Serving Guildford, Woking, Godalming and Farnham.",
-        "url": "https://onlinefix.co.uk/macbook-repair.html",
+        "name": "PC & Desktop Repair Guildford | Hardware & Software Fix Surrey",
+        "description": "No fix, no fee PC and desktop repair in Guildford, Surrey. Same-day hardware diagnosis, virus removal, SSD upgrades, RAM upgrades, Windows installation. 90-day warranty. Serving Guildford, Woking, Godalming and Farnham.",
+        "url": "https://onlinefix.co.uk/pc-repair.html",
         "isPartOf": {
             "@type": "WebSite",
             "name": "OnlineFix",
@@ -108,18 +108,18 @@
             "itemListElement": [
                 {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://onlinefix.co.uk/"},
                 {"@type": "ListItem", "position": 2, "name": "Services", "item": "https://onlinefix.co.uk/services.html"},
-                {"@type": "ListItem", "position": 3, "name": "MacBook Repair", "item": "https://onlinefix.co.uk/macbook-repair.html"}
+                {"@type": "ListItem", "position": 3, "name": "PC Repair", "item": "https://onlinefix.co.uk/pc-repair.html"}
             ]
         }
     }
     </script>
 
-    <!-- Service Schema - MacBook Repair -->
+    <!-- Service Schema - PC Repair -->
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
         "@type": "Service",
-        "serviceType": "MacBook Repair",
+        "serviceType": "PC Repair",
         "provider": {
             "@type": "LocalBusiness",
             "@id": "https://onlinefix.co.uk/#organization",
@@ -133,54 +133,54 @@
         ],
         "hasOfferCatalog": {
             "@type": "OfferCatalog",
-            "name": "MacBook Repair Services",
+            "name": "PC Repair Services",
             "itemListElement": [
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Logic Board Repair",
-                        "description": "Professional board-level repair for MacBook Pro and MacBook Air with no power, no backlight, kernel panics, or GPU failure using micro-soldering"
+                        "name": "Hardware Diagnosis & Repair",
+                        "description": "Professional hardware diagnosis and repair for desktop PCs including motherboard, PSU, RAM, and GPU fault finding and component replacement"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Screen Replacement",
-                        "description": "LCD and Retina display replacement for cracked, dead pixel, or flickering MacBook screens including MacBook Pro and MacBook Air models"
+                        "name": "Virus & Malware Removal",
+                        "description": "Complete virus, malware, and ransomware removal for slow PCs with pop-ups, redirects, or compromised security"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Battery Replacement",
-                        "description": "Genuine-spec battery replacement for MacBook Pro and MacBook Air with swollen battery, poor battery life, or not charging issues"
+                        "name": "SSD/HDD Upgrade",
+                        "description": "Solid state drive and hard drive upgrades for faster boot times, improved performance, and expanded storage capacity"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Keyboard Repair",
-                        "description": "Keyboard replacement and repair for stuck, unresponsive, or butterfly mechanism MacBook keyboards including top case replacement"
+                        "name": "RAM & Component Upgrade",
+                        "description": "RAM upgrades and component replacements to boost PC performance for multitasking, gaming, and professional workloads"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook SSD Upgrade & Data Recovery",
-                        "description": "SSD storage upgrade and data recovery for MacBook Pro and MacBook Air, including transfer from failing drives"
+                        "name": "Windows Installation & Setup",
+                        "description": "Clean Windows installation, OS migration, driver setup, and full system configuration for desktop PCs"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Water Damage Repair",
-                        "description": "Liquid damage diagnosis and board-level repair for MacBook Pro and MacBook Air with corrosion cleaning and component replacement"
+                        "name": "Overheating & Fan Repair",
+                        "description": "Thermal paste replacement, fan repair, dust cleaning, and cooling system restoration for overheating desktop PCs and gaming rigs"
                     }
                 }
             ]
@@ -188,7 +188,7 @@
     }
     </script>
 
-    <!-- FAQ Schema - MacBook Repair -->
+    <!-- FAQ Schema - PC Repair -->
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
@@ -196,50 +196,50 @@
         "mainEntity": [
             {
                 "@type": "Question",
-                "name": "How much does a MacBook screen replacement cost in Guildford?",
+                "name": "How much does a PC repair cost in Guildford?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "MacBook screen replacement at OnlineFix Guildford starts from £149 depending on the model. MacBook Air screens are typically less expensive than MacBook Pro Retina displays. The price includes the replacement display, professional fitting, and full testing. We operate a no fix, no fee policy and all repairs include a 90-day warranty."
+                    "text": "PC repair costs at OnlineFix Guildford depend on the issue. Hardware diagnosis starts from £30, virus removal from £35, and SSD upgrades from £40 (plus the cost of the drive). We provide a transparent quote before any work begins. We operate a no fix, no fee policy and all repairs include a 90-day warranty."
                 }
             },
             {
                 "@type": "Question",
-                "name": "Can you fix a MacBook that won't turn on?",
+                "name": "How long does a PC repair take?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes. A MacBook that won't turn on is usually caused by a faulty logic board, failed power IC, liquid damage, or a dead battery. At OnlineFix we diagnose the exact cause with board-level testing equipment and only charge for the specific repair needed. Most power-related MacBook repairs are completed within 24-48 hours."
+                    "text": "Most PC repairs at OnlineFix Guildford are completed same-day. Simple upgrades like RAM or SSD installation take 30-60 minutes. Virus removal and Windows installations typically take 1-3 hours. Hardware diagnosis and motherboard-level repairs may take 1-2 days depending on parts availability. We always provide a time estimate when you book your drop-off."
                 }
             },
             {
                 "@type": "Question",
-                "name": "Do you repair water-damaged MacBooks?",
+                "name": "Will my files and data be safe during PC repair?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes, we specialise in MacBook liquid damage repair. We perform ultrasonic cleaning of the logic board, replace corroded components using micro-soldering, and restore full functionality. The sooner you bring it in after a spill, the better the chances of a full recovery. No fix, no fee — if we can't save it, you don't pay."
+                    "text": "Yes, we prioritise data safety on every PC repair. For hardware upgrades and virus removal, your files remain intact. If a clean Windows installation is needed, we back up your data first. We never access personal files unnecessarily and always discuss data implications before starting any repair that could affect your stored files."
                 }
             },
             {
                 "@type": "Question",
-                "name": "How long does a MacBook repair take?",
+                "name": "Do you repair gaming PCs and custom builds?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Most MacBook repairs at OnlineFix Guildford are completed same-day or within 1-3 days. Battery and SSD swaps are typically same-day. Screen replacements and keyboard repairs take 24-48 hours. Logic board repairs may take 2-3 days for thorough diagnosis and testing. Unlike Apple Store or chains who send MacBooks away for weeks, we repair on-site in Guildford."
+                    "text": "Yes, we repair all types of gaming PCs and custom builds. Whether it's a GPU failure, overheating issues, PSU problems, or performance bottlenecks, we diagnose and fix it. We also offer upgrade consultations to help you get the best performance from your gaming rig within your budget."
                 }
             },
             {
                 "@type": "Question",
-                "name": "Is it worth repairing an old MacBook?",
+                "name": "Is there a warranty on PC repairs?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Often yes. An SSD upgrade and battery replacement can make a 2015-2019 MacBook feel brand new for a fraction of the cost of a replacement. We provide honest advice — if a repair doesn't make economic sense, we'll tell you upfront during our free diagnosis. No fix, no fee means zero risk to you."
+                    "text": "Yes, all PC repairs at OnlineFix come with a 90-day warranty as standard. This covers both parts and labour. If the same fault recurs within the warranty period, we fix it at no additional cost. We also operate a no fix, no fee policy — if we can't repair your PC, you don't pay."
                 }
             },
             {
                 "@type": "Question",
-                "name": "Is there a warranty on MacBook repairs?",
+                "name": "Can you advise on PC upgrades to improve performance?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes, all MacBook repairs at OnlineFix come with a 90-day warranty. We also operate a no fix, no fee policy — if we can't repair your MacBook, you don't pay. We stand behind our work and use quality replacement parts. If the same issue recurs within the 90-day warranty period, we'll fix it at no additional cost."
+                    "text": "Absolutely. We offer free upgrade consultations when you book a drop-off. Whether you need more RAM for multitasking, an SSD for faster boot times, or a GPU upgrade for gaming, we assess your current setup and recommend the most cost-effective upgrades. We can source and install components for you with our 90-day warranty included."
                 }
             }
         ]
@@ -287,7 +287,7 @@
 
         /* PAGE HEADER */
         .page-header { padding: 60px 0 0; background: linear-gradient(90deg, var(--hex-grid) 1px, transparent 1px) 0 0, linear-gradient(180deg, var(--hex-grid) 1px, transparent 1px) 0 0; background-size: 40px 40px; background-color: var(--hex-concrete); position: relative; overflow: hidden; }
-        .page-header::before { content: "FIG. 08 — MACBOOK REPAIR MANUAL"; position: absolute; top: 80px; left: 20px; font-family: monospace; font-size: 0.7rem; color: var(--hex-black); opacity: 0.6; }
+        .page-header::before { content: "FIG. 11 — PC REPAIR MANUAL"; position: absolute; top: 80px; left: 20px; font-family: monospace; font-size: 0.7rem; color: var(--hex-black); opacity: 0.6; }
         .page-header-content { max-width: 1400px; margin: 0 auto; padding: 4rem 20px; position: relative; z-index: 2; }
         .page-header-box { text-align: center; border: 2px solid var(--hex-black); padding: 3rem 4rem; background: var(--hex-white); box-shadow: 15px 15px 0px var(--hex-black); }
         .page-title { font-size: clamp(2rem, 6vw, 4rem); font-weight: 900; line-height: 0.9; text-transform: uppercase; letter-spacing: -2px; color: var(--hex-black); margin-bottom: 1rem; }
@@ -540,8 +540,8 @@
     <header class="page-header">
         <div class="page-header-content">
             <div class="page-header-box fade-in">
-                <h1 class="page-title">MACBOOK <span>REPAIR</span> GUILDFORD</h1>
-                <p class="page-subtitle">Same-Day MacBook Pro &amp; Air Repair // No Fix, No Fee // 90-Day Warranty</p>
+                <h1 class="page-title">PC &amp; DESKTOP <span>REPAIR</span> GUILDFORD</h1>
+                <p class="page-subtitle">Expert Desktop &amp; Gaming PC Repair // Upgrades &amp; Troubleshooting // 90-Day Warranty</p>
             </div>
         </div>
     </header>
@@ -550,29 +550,28 @@
         <!-- Models We Repair -->
         <section class="models-section" aria-labelledby="models-heading">
             <div class="container">
-                <h2 class="section-title fade-in" id="models-heading">"MODELS WE REPAIR"</h2>
-                <p class="section-subtitle fade-in">Every MacBook Generation Supported</p>
-                <div class="scroll-hint" aria-hidden="true">SCROLL &rarr;</div>
+                <h2 class="section-title fade-in" id="models-heading">"SYSTEMS WE REPAIR"</h2>
+                <p class="section-subtitle fade-in">Every Desktop &amp; PC Type Supported</p>
                 <div class="models-grid">
                     <div class="model-item fade-in">
-                        <div class="model-icon"><i class="fas fa-laptop" aria-hidden="true"></i></div>
-                        <div class="model-name">MacBook Pro</div>
-                        <div class="model-years">2012 &ndash; 2024 (Intel &amp; M-Series)</div>
-                    </div>
-                    <div class="model-item fade-in">
-                        <div class="model-icon"><i class="fas fa-laptop" aria-hidden="true"></i></div>
-                        <div class="model-name">MacBook Air</div>
-                        <div class="model-years">2013 &ndash; 2024 (Intel &amp; M-Series)</div>
-                    </div>
-                    <div class="model-item fade-in">
-                        <div class="model-icon"><i class="fas fa-laptop" aria-hidden="true"></i></div>
-                        <div class="model-name">MacBook 12&quot;</div>
-                        <div class="model-years">2015 &ndash; 2017 (Retina)</div>
+                        <div class="model-icon"><i class="fas fa-gamepad" aria-hidden="true"></i></div>
+                        <div class="model-name">Gaming PCs</div>
+                        <div class="model-years">Custom Builds &amp; Branded</div>
                     </div>
                     <div class="model-item fade-in">
                         <div class="model-icon"><i class="fas fa-desktop" aria-hidden="true"></i></div>
-                        <div class="model-name">iMac / Mac Mini</div>
-                        <div class="model-years">Select Models Supported</div>
+                        <div class="model-name">Desktop PCs</div>
+                        <div class="model-years">Dell, HP, Lenovo, Acer</div>
+                    </div>
+                    <div class="model-item fade-in">
+                        <div class="model-icon"><i class="fas fa-tv" aria-hidden="true"></i></div>
+                        <div class="model-name">All-in-One PCs</div>
+                        <div class="model-years">iMac, Surface Studio</div>
+                    </div>
+                    <div class="model-item fade-in">
+                        <div class="model-icon"><i class="fas fa-microchip" aria-hidden="true"></i></div>
+                        <div class="model-name">Custom Builds</div>
+                        <div class="model-years">Upgrades &amp; New Builds</div>
                     </div>
                 </div>
             </div>
@@ -582,150 +581,149 @@
         <section class="issues-section" aria-labelledby="issues-heading">
             <div class="container">
                 <h2 class="section-title fade-in" id="issues-heading">"COMMON ISSUES WE FIX"</h2>
-                <p class="section-subtitle fade-in">Board-Level Micro-Soldering &amp; Component Repair</p>
-                <div class="scroll-hint" aria-hidden="true">SCROLL &rarr;</div>
+                <p class="section-subtitle fade-in">Expert Diagnosis &amp; Professional PC Repair</p>
                 <div class="issues-grid">
-                    <!-- LOGIC BOARD REPAIR -->
+                    <!-- HARDWARE DIAGNOSIS & REPAIR -->
                     <article class="issue-card fade-in" data-issue-num="ISSUE_01">
                         <div class="issue-header">
-                            <div class="issue-icon"><i class="fas fa-microchip" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">Logic Board Repair</h3>
+                            <div class="issue-icon"><i class="fas fa-wrench" aria-hidden="true"></i></div>
+                            <h3 class="issue-title">Hardware Diagnosis &amp; Repair</h3>
                         </div>
-                        <p class="issue-description">The logic board is the brain of your MacBook. Failed power ICs, blown capacitors, GPU faults, and short circuits can all cause a dead or malfunctioning machine. We perform board-level micro-soldering to diagnose and replace the specific failed components — saving your MacBook when Apple says it needs a full replacement.</p>
+                        <p class="issue-description">When your PC won't power on, crashes randomly, or displays error codes, the problem is usually a failed hardware component. We systematically test every part of your system — motherboard, PSU, RAM, GPU, and storage — to pinpoint the exact fault. Once identified, we replace the failed component with a quality part and fully stress-test before returning your machine.</p>
                         <p class="issue-subtitle">Symptoms:</p>
                         <ul class="issue-symptoms">
-                            <li>MacBook completely dead — no power, no light</li>
-                            <li>Turns on but no display (backlight failure)</li>
-                            <li>Random kernel panics and crashes</li>
-                            <li>USB-C / Thunderbolt ports not working</li>
-                            <li>Fan spinning at full speed constantly</li>
+                            <li>PC won't turn on or no display output</li>
+                            <li>Random crashes, freezes, or blue screens</li>
+                            <li>Beeping sounds or error codes on startup</li>
+                            <li>PC restarts on its own repeatedly</li>
+                            <li>Burning smell or visible damage to components</li>
                         </ul>
                         <div class="issue-bottom">
                             <div class="issue-pricing">
                                 <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;95</div>
+                                <div class="issue-price">&pound;30</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Board Repair</a>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Diagnosis</a>
                         </div>
                     </article>
 
-                    <!-- SCREEN REPLACEMENT -->
+                    <!-- VIRUS & MALWARE REMOVAL -->
                     <article class="issue-card fade-in" data-issue-num="ISSUE_02">
                         <div class="issue-header">
-                            <div class="issue-icon"><i class="fas fa-desktop" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">Screen Replacement</h3>
+                            <div class="issue-icon"><i class="fas fa-shield-alt" aria-hidden="true"></i></div>
+                            <h3 class="issue-title">Virus &amp; Malware Removal</h3>
                         </div>
-                        <p class="issue-description">Cracked glass, dead pixels, vertical lines, or a completely black display — we replace MacBook screens with quality Retina-grade panels. Whether it's a MacBook Pro 13&quot;, 14&quot;, 15&quot;, or 16&quot;, or a MacBook Air, we have screens in stock for most models and complete the swap with precise calibration.</p>
+                        <p class="issue-description">A virus-infected PC slows to a crawl, bombards you with pop-ups, and puts your personal data at risk. We perform a deep scan to identify and remove all malware, adware, spyware, and ransomware. After cleaning, we install proper security software and optimise your system to prevent reinfection. Your files and data are preserved throughout the process.</p>
                         <p class="issue-subtitle">Symptoms:</p>
                         <ul class="issue-symptoms">
-                            <li>Cracked or shattered display glass</li>
-                            <li>Vertical coloured lines across the screen</li>
-                            <li>Black screen but MacBook sounds on</li>
-                            <li>Flickering or dim display</li>
-                            <li>Dead pixels or discoloured patches</li>
+                            <li>PC running extremely slowly</li>
+                            <li>Constant pop-ups and browser redirects</li>
+                            <li>Unfamiliar programs appearing on desktop</li>
+                            <li>Files encrypted or locked by ransomware</li>
+                            <li>Antivirus disabled or cannot be installed</li>
                         </ul>
                         <div class="issue-bottom">
                             <div class="issue-pricing">
                                 <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;149</div>
+                                <div class="issue-price">&pound;35</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Screen Repair</a>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Virus Removal</a>
                         </div>
                     </article>
 
-                    <!-- BATTERY REPLACEMENT -->
+                    <!-- SSD/HDD UPGRADE -->
                     <article class="issue-card fade-in" data-issue-num="ISSUE_03">
                         <div class="issue-header">
-                            <div class="issue-icon"><i class="fas fa-battery-quarter" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">Battery Replacement</h3>
+                            <div class="issue-icon"><i class="fas fa-hdd" aria-hidden="true"></i></div>
+                            <h3 class="issue-title">SSD/HDD Upgrade</h3>
                         </div>
-                        <p class="issue-description">MacBook batteries degrade over time — after 500-1000 charge cycles, capacity drops significantly. Swollen batteries are a safety hazard that can warp the trackpad or case. We replace batteries with high-quality cells that restore your MacBook to full-day battery life. Most battery swaps are completed same-day.</p>
+                        <p class="issue-description">The single biggest upgrade you can make to an ageing PC is swapping the old hard drive for a solid state drive. Boot times drop from minutes to seconds, programs open instantly, and everything feels snappier. We clone your existing drive so you keep all your files, programs, and settings — or perform a fresh install if you prefer a clean start.</p>
                         <p class="issue-subtitle">Symptoms:</p>
                         <ul class="issue-symptoms">
-                            <li>"Service Battery" or "Replace Soon" warning</li>
-                            <li>Battery drains in under 2 hours</li>
-                            <li>Swollen/bulging trackpad or bottom case</li>
-                            <li>MacBook only works when plugged in</li>
-                            <li>Random shutdowns at 20-40% battery</li>
+                            <li>PC takes several minutes to boot up</li>
+                            <li>Programs and files slow to open</li>
+                            <li>Hard drive making clicking or grinding noises</li>
+                            <li>Running out of storage space</li>
+                            <li>Disk usage stuck at 100% in Task Manager</li>
                         </ul>
                         <div class="issue-bottom">
                             <div class="issue-pricing">
-                                <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;79</div>
+                                <div class="price-text">Starting From (labour)</div>
+                                <div class="issue-price">&pound;40</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Battery Swap</a>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book SSD Upgrade</a>
                         </div>
                     </article>
 
-                    <!-- KEYBOARD REPAIR -->
+                    <!-- RAM & COMPONENT UPGRADE -->
                     <article class="issue-card fade-in" data-issue-num="ISSUE_04">
                         <div class="issue-header">
-                            <div class="issue-icon"><i class="fas fa-keyboard" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">Keyboard Repair</h3>
+                            <div class="issue-icon"><i class="fas fa-memory" aria-hidden="true"></i></div>
+                            <h3 class="issue-title">RAM &amp; Component Upgrade</h3>
                         </div>
-                        <p class="issue-description">The infamous butterfly keyboard (2016-2019 MacBook Pro) is notorious for stuck and unresponsive keys. Even scissor-switch keyboards on newer models can fail from dust or liquid ingress. We replace faulty keyboards — including full top case swaps when needed — restoring every key to reliable operation.</p>
+                        <p class="issue-description">If your PC struggles with multiple tabs, freezes during video editing, or stutters in games, a RAM upgrade can transform performance. We assess your current configuration, identify the maximum supported memory, and install compatible modules. We also handle GPU upgrades, PSU swaps, and other component replacements to keep your system running at its best.</p>
                         <p class="issue-subtitle">Symptoms:</p>
                         <ul class="issue-symptoms">
-                            <li>Keys stuck, mushy, or unresponsive</li>
-                            <li>Double-typing or ghost key presses</li>
-                            <li>Backlight not working on some keys</li>
-                            <li>Spacebar or shift key intermittent</li>
-                            <li>Keys physically missing or broken</li>
+                            <li>PC slows down with multiple programs open</li>
+                            <li>Games stutter or lag during play</li>
+                            <li>"Out of memory" errors appearing</li>
+                            <li>Video editing or rendering takes too long</li>
+                            <li>System feels sluggish despite SSD upgrade</li>
                         </ul>
                         <div class="issue-bottom">
                             <div class="issue-pricing">
-                                <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;89</div>
+                                <div class="price-text">Starting From (labour)</div>
+                                <div class="issue-price">&pound;25</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Keyboard Fix</a>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Upgrade</a>
                         </div>
                     </article>
 
-                    <!-- SSD UPGRADE & DATA RECOVERY -->
+                    <!-- WINDOWS INSTALLATION & SETUP -->
                     <article class="issue-card fade-in" data-issue-num="ISSUE_05">
                         <div class="issue-header">
-                            <div class="issue-icon"><i class="fas fa-hdd" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">SSD Upgrade &amp; Data Recovery</h3>
+                            <div class="issue-icon"><i class="fab fa-windows" aria-hidden="true"></i></div>
+                            <h3 class="issue-title">Windows Installation &amp; Setup</h3>
                         </div>
-                        <p class="issue-description">Running out of storage or stuck on a slow spinning hard drive? We upgrade older MacBooks to fast NVMe SSDs — making them feel like new machines. For failing drives, we recover your data before it's lost. We handle everything from 128GB to 2TB upgrades, including OS migration so you're back up and running immediately.</p>
+                        <p class="issue-description">Whether you need a clean Windows install to fix a corrupted system, an upgrade from an older version, or a fresh setup on a new build, we handle it all. We install the latest Windows version, configure all drivers, apply security updates, and set up your accounts. If needed, we migrate your files and programs from your old installation so nothing is lost.</p>
                         <p class="issue-subtitle">Symptoms:</p>
                         <ul class="issue-symptoms">
-                            <li>"Startup disk almost full" warnings</li>
-                            <li>Extremely slow boot times (spinning wheel)</li>
-                            <li>Apps freezing or beach-balling constantly</li>
-                            <li>Clicking noises from hard drive</li>
-                            <li>Files disappearing or corrupted</li>
+                            <li>Windows won't boot or stuck in repair loop</li>
+                            <li>Constant blue screen errors (BSOD)</li>
+                            <li>System corrupted after failed update</li>
+                            <li>Need to upgrade from Windows 10 to 11</li>
+                            <li>New build or new SSD needs OS installed</li>
                         </ul>
                         <div class="issue-bottom">
                             <div class="issue-pricing">
                                 <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;69</div>
+                                <div class="issue-price">&pound;35</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book SSD Upgrade</a>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Windows Install</a>
                         </div>
                     </article>
 
-                    <!-- WATER DAMAGE -->
+                    <!-- OVERHEATING & FAN REPAIR -->
                     <article class="issue-card fade-in" data-issue-num="ISSUE_06">
                         <div class="issue-header">
-                            <div class="issue-icon"><i class="fas fa-tint" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">Water Damage Repair</h3>
+                            <div class="issue-icon"><i class="fas fa-thermometer-full" aria-hidden="true"></i></div>
+                            <h3 class="issue-title">Overheating &amp; Fan Repair</h3>
                         </div>
-                        <p class="issue-description">Spilled coffee, tea, or water on your MacBook? Time is critical. Liquid causes corrosion that spreads across the logic board within hours. We perform ultrasonic cleaning to remove all corrosion, then diagnose and replace any damaged components using micro-soldering. The sooner you bring it in, the better the recovery chances.</p>
+                        <p class="issue-description">Dust buildup, dried-out thermal paste, and failing fans are the top causes of PC overheating. An overheating PC throttles performance, crashes under load, and can permanently damage your CPU or GPU. We deep-clean your system, replace thermal compound with high-quality paste, repair or replace faulty fans, and ensure proper airflow is restored throughout the case.</p>
                         <p class="issue-subtitle">Symptoms:</p>
                         <ul class="issue-symptoms">
-                            <li>MacBook dead after liquid spill</li>
-                            <li>Keyboard keys sticking or not working</li>
-                            <li>Trackpad clicking on its own</li>
-                            <li>Screen flickering or discoloured</li>
-                            <li>Charging intermittent or not working</li>
+                            <li>PC shuts down during gaming or heavy use</li>
+                            <li>Fans running loud constantly at full speed</li>
+                            <li>CPU or GPU temperatures above 90&deg;C</li>
+                            <li>Performance drops after 10-15 minutes of use</li>
+                            <li>Visible dust buildup in vents and fans</li>
                         </ul>
                         <div class="issue-bottom">
                             <div class="issue-pricing">
                                 <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;85</div>
+                                <div class="issue-price">&pound;30</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Water Damage Repair</a>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Cooling Repair</a>
                         </div>
                     </article>
                 </div>
@@ -735,8 +733,8 @@
         <!-- Emergency CTA -->
         <section class="emergency-section" aria-label="Emergency repair contact">
             <div class="container">
-                <h2>"MACBOOK DOWN?"</h2>
-                <p>Don't replace it — repair it. Same-day service available. Free diagnosis. No fix, no fee. Call to book a drop-off.</p>
+                <h2>"PC NOT WORKING?"</h2>
+                <p>Don't overpay at PC World — get it fixed fast. Same-day repairs available. Free diagnosis. No fix, no fee. Call to book a drop-off.</p>
                 <a href="tel:+447940730537" class="emergency-btn">
                     <i class="fas fa-phone-alt" aria-hidden="true"></i> Call to Book — 07940 730537
                 </a>
@@ -747,17 +745,17 @@
         <section class="why-section" aria-labelledby="why-heading">
             <div class="container">
                 <h2 class="section-title fade-in" id="why-heading">"WHY CHOOSE ONLINEFIX?"</h2>
-                <p class="section-subtitle fade-in">Board-Level Repair. Not Just Part Swapping.</p>
+                <p class="section-subtitle fade-in">Fast, Affordable, Professional PC Repair</p>
                 <div class="why-grid">
                     <div class="why-item fade-in">
                         <div class="why-icon"><i class="fas fa-shield-alt" aria-hidden="true"></i></div>
                         <div class="why-title">No Fix, No Fee</div>
-                        <p class="why-description">If we can't repair your MacBook, you don't pay a penny. Zero risk — we only charge for successful repairs.</p>
+                        <p class="why-description">If we can't repair your PC, you don't pay a penny. Zero risk — we only charge for successful repairs.</p>
                     </div>
                     <div class="why-item fade-in">
                         <div class="why-icon"><i class="fas fa-bolt" aria-hidden="true"></i></div>
                         <div class="why-title">Same-Day Repairs</div>
-                        <p class="why-description">Battery swaps and SSD upgrades done same-day. Unlike Apple Store who quote 5-7 business days, we repair on-site in Guildford.</p>
+                        <p class="why-description">Most PC repairs and upgrades completed same-day. Unlike Currys who quote 1-2 weeks, we fix it fast at your booked drop-off.</p>
                     </div>
                     <div class="why-item fade-in">
                         <div class="why-icon"><i class="fas fa-certificate" aria-hidden="true"></i></div>
@@ -765,21 +763,21 @@
                         <p class="why-description">Every repair backed by our 90-day warranty. If the same fault returns within 90 days, we fix it again completely free.</p>
                     </div>
                     <div class="why-item fade-in">
-                        <div class="why-icon"><i class="fas fa-microchip" aria-hidden="true"></i></div>
-                        <div class="why-title">Board-Level Repair</div>
-                        <p class="why-description">We micro-solder individual components — saving your MacBook when Apple says "replace the whole board" for &pound;500+.</p>
+                        <div class="why-icon"><i class="fas fa-calendar-check" aria-hidden="true"></i></div>
+                        <div class="why-title">Easy Scheduled Drop-Off</div>
+                        <p class="why-description">Book a convenient drop-off time at our Guildford workshop. Open 10am&ndash;10pm, 7 days a week. Serving Woking, Godalming &amp; Farnham too.</p>
                     </div>
                 </div>
                 <div class="why-vs fade-in">
-                    <div class="why-vs-title">OnlineFix vs. Apple Store &amp; Others</div>
+                    <div class="why-vs-title">OnlineFix vs. PC World / Currys</div>
                     <div class="why-vs-row">
                         <div class="why-vs-col">
                             <div class="why-vs-label">OnlineFix</div>
-                            <div class="why-vs-value highlight">Board-level repair from &pound;79<br>Same-day for most repairs<br>No fix, no fee<br>90-day warranty<br>Easy scheduled drop-offs</div>
+                            <div class="why-vs-value highlight">Hardware diagnosis from &pound;30<br>Same-day, often under 2 hours<br>No fix, no fee<br>90-day warranty<br>Easy scheduled drop-offs</div>
                         </div>
                         <div class="why-vs-col">
-                            <div class="why-vs-label">Apple Store / Others</div>
-                            <div class="why-vs-value">"Replace entire board" from &pound;500+<br>5-7 business days minimum<br>Diagnostic fees charged upfront<br>Limited warranty on parts only<br>Long wait for appointments</div>
+                            <div class="why-vs-label">PC World / Currys</div>
+                            <div class="why-vs-value">Diagnostic fees from &pound;50+<br>1-2 weeks turnaround typical<br>Charges even if not repaired<br>Limited warranty on parts only<br>Long queues and waiting times</div>
                         </div>
                     </div>
                 </div>
@@ -790,12 +788,12 @@
         <section class="process-section" aria-labelledby="process-heading">
             <div class="container">
                 <h2 class="section-title fade-in" id="process-heading">"HOW IT WORKS"</h2>
-                <p class="section-subtitle fade-in">Drop Off &rarr; Diagnose &rarr; Repair &rarr; Collect</p>
+                <p class="section-subtitle fade-in">Book &rarr; Drop Off &rarr; Repair &rarr; Collect</p>
                 <div class="process-grid">
                     <div class="process-item fade-in">
                         <div class="process-number">01</div>
                         <h4>Free Diagnosis</h4>
-                        <p>Call us or describe the issue over the phone. Book a drop-off and we diagnose the fault at no cost — including board-level testing.</p>
+                        <p>Call us or send a message describing the issue. Book a convenient drop-off time and we diagnose the fault at no cost.</p>
                     </div>
                     <div class="process-item fade-in">
                         <div class="process-number">02</div>
@@ -805,12 +803,12 @@
                     <div class="process-item fade-in">
                         <div class="process-number">03</div>
                         <h4>Expert Repair</h4>
-                        <p>Professional micro-soldering and component-level repair using quality parts. Your data stays safe throughout — we never wipe without asking.</p>
+                        <p>Professional repair using quality replacement parts. Your data stays completely safe — we never access or wipe your files.</p>
                     </div>
                     <div class="process-item fade-in">
                         <div class="process-number">04</div>
                         <h4>Tested &amp; Returned</h4>
-                        <p>Every repair is stress-tested with diagnostics before collection. Your MacBook comes back working perfectly, with a 90-day warranty.</p>
+                        <p>Every repair is fully stress-tested — hardware, software, thermals, and stability — before collection. 90-day warranty included.</p>
                     </div>
                 </div>
             </div>
@@ -820,42 +818,42 @@
         <section class="faq-section" aria-labelledby="faq-heading">
             <div class="container">
                 <h2 class="section-title fade-in" id="faq-heading">"FAQ"</h2>
-                <p class="section-subtitle fade-in">Common Questions About MacBook Repair</p>
+                <p class="section-subtitle fade-in">Common Questions About PC Repair</p>
                 <div class="faq-list">
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">How much does a MacBook screen replacement cost in Guildford?</button>
+                        <button class="faq-question" aria-expanded="false">How much does a PC repair cost in Guildford?</button>
                         <div class="faq-answer" role="region">
-                            <p>MacBook screen replacement at OnlineFix Guildford starts from &pound;149 depending on the model. MacBook Air screens are typically less expensive than MacBook Pro Retina displays. The price includes the replacement display, professional fitting, and full testing. We operate a <strong>no fix, no fee</strong> policy and all repairs include a <strong>90-day warranty</strong>.</p>
+                            <p>PC repair costs at OnlineFix Guildford depend on the issue. Hardware diagnosis starts from &pound;30, virus removal from &pound;35, and SSD upgrades from &pound;40 (plus the cost of the drive). We provide a <strong>transparent quote</strong> before any work begins — no hidden fees. We operate a <strong>no fix, no fee</strong> policy and all repairs include a <strong>90-day warranty</strong>.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">Can you fix a MacBook that won't turn on?</button>
+                        <button class="faq-question" aria-expanded="false">How long does a PC repair take?</button>
                         <div class="faq-answer" role="region">
-                            <p>Yes. A MacBook that won't turn on is usually caused by a faulty logic board, failed power IC, liquid damage, or a dead battery. At OnlineFix Guildford, we diagnose the exact cause with board-level testing equipment and only charge for the specific repair needed. Our <strong>no fix, no fee</strong> policy means you won't pay if we can't resolve it, and all repairs include a <strong>90-day warranty</strong>. Most power-related MacBook repairs are completed within <strong>24-48 hours</strong>.</p>
+                            <p>Most PC repairs are completed <strong>same-day</strong>. Simple upgrades like RAM or SSD installation take 30-60 minutes. Virus removal and Windows installations typically take 1-3 hours. Hardware diagnosis and motherboard-level repairs may take 1-2 days depending on parts availability. We always provide a time estimate when you <strong>book your drop-off</strong>.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">Do you repair water-damaged MacBooks?</button>
+                        <button class="faq-question" aria-expanded="false">Will my files and data be safe during PC repair?</button>
                         <div class="faq-answer" role="region">
-                            <p>Yes, we specialise in MacBook liquid damage repair. We perform ultrasonic cleaning of the logic board, replace corroded components using micro-soldering, and restore full functionality. The sooner you bring it in after a spill, the better the chances. <strong>No fix, no fee</strong> — if we can't save it, you don't pay. <strong>Call to book your drop-off</strong> at our Guildford shop.</p>
+                            <p>Yes, we prioritise <strong>data safety</strong> on every PC repair. For hardware upgrades and virus removal, your files remain intact. If a clean Windows installation is needed, we back up your data first and discuss all options with you. We never access personal files unnecessarily and always explain data implications before starting any repair. We recommend a backup before any repair as best practice.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">How long does a MacBook repair take?</button>
+                        <button class="faq-question" aria-expanded="false">Do you repair gaming PCs and custom builds?</button>
                         <div class="faq-answer" role="region">
-                            <p>Most MacBook repairs are completed <strong>same-day or within 1-3 days</strong>. Battery swaps and SSD upgrades are typically same-day. Screen replacements and keyboard repairs take 24-48 hours. Logic board repairs may take 2-3 days for thorough testing. Unlike the Apple Store who quote 5-7 business days, we repair on-site in Guildford. Serving Guildford, Woking, Godalming, and Farnham.</p>
+                            <p>Yes, we repair <strong>all types of gaming PCs and custom builds</strong>. Whether it's a GPU failure, overheating issues, PSU problems, or performance bottlenecks — we diagnose and fix it. We also offer upgrade consultations to help you get the best performance from your gaming rig within your budget. <strong>Call to book your drop-off</strong> at our Guildford workshop.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">Is it worth repairing an old MacBook?</button>
+                        <button class="faq-question" aria-expanded="false">Is there a warranty on PC repairs?</button>
                         <div class="faq-answer" role="region">
-                            <p>Often yes. An SSD upgrade and battery replacement can make a 2015-2019 MacBook feel brand new for a fraction of the cost of a replacement. We provide honest advice — if a repair doesn't make economic sense, we'll tell you upfront during our <strong>free diagnosis</strong>. <strong>No fix, no fee</strong> means zero risk to you.</p>
+                            <p>Yes, every PC repair at OnlineFix comes with a <strong>90-day warranty</strong> as standard. This covers both parts and labour. If the same fault recurs within the warranty period, we fix it at no additional cost. We also operate a <strong>no fix, no fee</strong> policy — unlike PC World or Currys, there's no diagnostic fee and no risk to you.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">Is there a warranty on MacBook repairs?</button>
+                        <button class="faq-question" aria-expanded="false">Can you advise on PC upgrades to improve performance?</button>
                         <div class="faq-answer" role="region">
-                            <p>Yes, every MacBook repair at OnlineFix comes with a <strong>90-day warranty</strong> as standard. We stand behind every repair and use quality replacement components. If the same issue recurs within the warranty period, we'll fix it at no additional cost. We also operate a <strong>no fix, no fee</strong> policy — unlike the Apple Store, there's no diagnostic fee and no risk to you.</p>
+                            <p>Absolutely. We offer <strong>free upgrade consultations</strong> when you book a drop-off. Whether you need more RAM for multitasking, an SSD for faster boot times, or a GPU upgrade for gaming, we assess your current setup and recommend the most cost-effective upgrades. We source and install components for you with our <strong>90-day warranty</strong> included on all work.</p>
                         </div>
                     </div>
                 </div>
@@ -865,12 +863,12 @@
         <section style="padding: 3rem 0; border-top: 2px solid var(--hex-black); background: var(--hex-concrete);" aria-label="Other repair services">
             <div class="container">
                 <h2 style="font-size: clamp(1.3rem, 3vw, 1.8rem); font-weight: 900; text-transform: uppercase; text-align: center; margin-bottom: 0.5rem;">"OTHER SERVICES"</h2>
-                <p style="text-align: center; font-family: monospace; color: #666; font-size: 0.85rem; margin-bottom: 2rem; text-transform: uppercase;">We repair more than just MacBooks</p>
+                <p style="text-align: center; font-family: monospace; color: #666; font-size: 0.85rem; margin-bottom: 2rem; text-transform: uppercase;">We repair more than just PCs</p>
                 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; max-width: 900px; margin: 0 auto;">
                     <a href="iphone-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-mobile-alt" aria-hidden="true" style="color: var(--hex-accent);"></i> iPhone Repair</a>
                     <a href="console-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-gamepad" aria-hidden="true" style="color: var(--hex-accent);"></i> Console Repair</a>
+                    <a href="macbook-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-laptop" aria-hidden="true" style="color: var(--hex-accent);"></i> MacBook Repair</a>
                     <a href="tablet-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-tablet-alt" aria-hidden="true" style="color: var(--hex-accent);"></i> Tablet Repair</a>
-                    <a href="pc-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-desktop" aria-hidden="true" style="color: var(--hex-accent);"></i> PC Repair</a>
                     <a href="data-recovery.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-hdd" aria-hidden="true" style="color: var(--hex-accent);"></i> Data Recovery</a>
                 </div>
             </div>
@@ -883,7 +881,7 @@
             <div class="footer-grid">
                 <div class="footer-column">
                     <h4>"ONLINEFIX"</h4>
-                    <p style="font-family: monospace; color: #999;">Expert electronics &amp; MacBook repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
+                    <p style="font-family: monospace; color: #999;">Expert electronics &amp; PC repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div class="social-links" style="margin-top: 1rem; font-size: 1.5rem;">
                         <a href="https://instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
                         <a href="https://tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
@@ -983,24 +981,6 @@
             el.style.animationPlayState = 'paused';
             fadeObserver.observe(el);
         });
-
-        // Mobile scroll nudge
-        if (window.innerWidth < 768) {
-            const scrollGrids = document.querySelectorAll('.issues-grid, .models-grid');
-            const nudgeObserver = new IntersectionObserver((entries) => {
-                entries.forEach(entry => {
-                    if (entry.isIntersecting) {
-                        const target = entry.target;
-                        setTimeout(() => {
-                            target.scrollBy({ left: 50, behavior: 'smooth' });
-                            setTimeout(() => { target.scrollBy({ left: -50, behavior: 'smooth' }); }, 800);
-                        }, 500);
-                        nudgeObserver.unobserve(target);
-                    }
-                });
-            }, { threshold: 0.6 });
-            scrollGrids.forEach(grid => nudgeObserver.observe(grid));
-        }
     </script>
 </body>
 </html>

--- a/reviews.html
+++ b/reviews.html
@@ -582,6 +582,9 @@
                         <li><a href="iphone-repair.html">iPhone Repair</a></li>
                         <li><a href="console-repair.html">Console Repair</a></li>
                         <li><a href="macbook-repair.html">MacBook Repair</a></li>
+                        <li><a href="tablet-repair.html">Tablet Repair</a></li>
+                        <li><a href="pc-repair.html">PC Repair</a></li>
+                        <li><a href="data-recovery.html">Data Recovery</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>

--- a/services.html
+++ b/services.html
@@ -801,6 +801,9 @@
                         <li><a href="iphone-repair.html">iPhone Repair</a></li>
                         <li><a href="console-repair.html">Console Repair</a></li>
                         <li><a href="macbook-repair.html">MacBook Repair</a></li>
+                        <li><a href="tablet-repair.html">Tablet Repair</a></li>
+                        <li><a href="pc-repair.html">PC Repair</a></li>
+                        <li><a href="data-recovery.html">Data Recovery</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -41,6 +41,30 @@
     <priority>0.9</priority>
   </url>
 
+  <!-- Tablet Repair landing page - High priority, service-specific SEO page -->
+  <url>
+    <loc>https://onlinefix.co.uk/tablet-repair.html</loc>
+    <lastmod>2026-02-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <!-- PC Repair landing page - High priority, service-specific SEO page -->
+  <url>
+    <loc>https://onlinefix.co.uk/pc-repair.html</loc>
+    <lastmod>2026-02-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <!-- Data Recovery landing page - High priority, service-specific SEO page -->
+  <url>
+    <loc>https://onlinefix.co.uk/data-recovery.html</loc>
+    <lastmod>2026-02-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
   <!-- Contact page - High priority, rarely changes -->
   <url>
     <loc>https://onlinefix.co.uk/contact.html</loc>

--- a/tablet-repair.html
+++ b/tablet-repair.html
@@ -11,13 +11,13 @@
     <!-- Security & Privacy -->
     <meta name="referrer" content="strict-origin-when-cross-origin">
 
-    <!-- SEO Meta Tags - MACBOOK REPAIR LANDING PAGE -->
-    <title>MacBook Repair Guildford | Logic Board &amp; Screen Fix Surrey | Same-Day | OnlineFix</title>
-    <meta name="description" content="Expert MacBook repair in Guildford, Surrey. Logic board repair, screen replacement, SSD upgrade, battery swap, keyboard fix. Same-day service — by appointment only. No fix, no fee. 90-day warranty. Call 07940 730537.">
-    <meta name="keywords" content="MacBook repair Guildford, MacBook screen replacement Surrey, MacBook logic board repair, MacBook battery replacement Guildford, MacBook Pro repair near me, MacBook Air repair Guildford, laptop repair Guildford, MacBook keyboard repair, MacBook SSD upgrade, MacBook not turning on, MacBook water damage repair, MacBook repair Woking, MacBook repair Godalming, MacBook repair Farnham, no fix no fee laptop repair">
+    <!-- SEO Meta Tags - TABLET REPAIR LANDING PAGE -->
+    <title>iPad &amp; Tablet Repair Guildford | Screen &amp; Battery Fix Surrey | Same-Day | OnlineFix</title>
+    <meta name="description" content="Expert iPad repair and tablet repair in Guildford, Surrey. Screen replacement, battery swap, charging port fix, water damage recovery. Same-day service — by appointment only. No fix, no fee. 90-day warranty. Call 07940 730537.">
+    <meta name="keywords" content="iPad repair Guildford, tablet repair Surrey, iPad screen replacement Guildford, Samsung tablet repair, iPad battery replacement, iPad charging port repair, iPad water damage repair, tablet screen repair near me, iPad repair Woking, iPad repair Godalming, iPad repair Farnham, no fix no fee tablet repair, same day iPad repair Guildford, iPad Pro repair, iPad Air repair, iPad Mini repair, Samsung Galaxy Tab repair">
     <meta name="author" content="OnlineFix - Tomas">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
-    <link rel="canonical" href="https://onlinefix.co.uk/macbook-repair.html">
+    <link rel="canonical" href="https://onlinefix.co.uk/tablet-repair.html">
     <link rel="sitemap" type="application/xml" href="/sitemap.xml">
 
     <!-- Local SEO Geo-Tags -->
@@ -28,20 +28,20 @@
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://onlinefix.co.uk/macbook-repair.html">
+    <meta property="og:url" content="https://onlinefix.co.uk/tablet-repair.html">
     <meta property="og:site_name" content="OnlineFix Guildford">
-    <meta property="og:title" content="MacBook Repair Guildford | Logic Board & Screen Fix | No Fix No Fee">
-    <meta property="og:description" content="Broken MacBook? No fix, no fee. Expert MacBook Pro & Air repair in Guildford. Logic board, screen, battery, keyboard & SSD repairs. Same-day service. 90-day warranty.">
+    <meta property="og:title" content="iPad & Tablet Repair Guildford | Screen & Battery Fix | No Fix No Fee">
+    <meta property="og:description" content="Broken iPad or tablet? No fix, no fee. Expert iPad screen replacement, battery swap, charging port repair &amp; water damage recovery in Guildford. Same-day service. 90-day warranty.">
     <meta property="og:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="OnlineFix MacBook Repair - Logic Board Screen Battery Repair Guildford">
+    <meta property="og:image:alt" content="OnlineFix iPad & Tablet Repair - Screen Battery Charging Port Repair Guildford">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://onlinefix.co.uk/macbook-repair.html">
-    <meta property="twitter:title" content="MacBook Repair Guildford | Same-Day Fix | No Fix No Fee">
-    <meta property="twitter:description" content="MacBook Pro & Air repair in Guildford. Logic board, screen, battery, keyboard & SSD. Same-day service. 90-day warranty. Appointment only.">
+    <meta property="twitter:url" content="https://onlinefix.co.uk/tablet-repair.html">
+    <meta property="twitter:title" content="iPad & Tablet Repair Guildford | Same-Day Fix | No Fix No Fee">
+    <meta property="twitter:description" content="iPad &amp; tablet screen, battery &amp; charging port repair in Guildford. Same-day service. 90-day warranty. Appointment only.">
     <meta property="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
 
     <!-- Favicon -->
@@ -80,8 +80,8 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "MacBook Repair",
-                "item": "https://onlinefix.co.uk/macbook-repair.html"
+                "name": "Tablet Repair",
+                "item": "https://onlinefix.co.uk/tablet-repair.html"
             }
         ]
     }
@@ -92,9 +92,9 @@
     {
         "@context": "https://schema.org",
         "@type": "WebPage",
-        "name": "MacBook Repair Guildford | Logic Board & Screen Fix Surrey",
-        "description": "No fix, no fee MacBook repair in Guildford, Surrey. Same-day MacBook Pro and MacBook Air repair. Logic board repair, screen replacement, SSD upgrade, battery swap, keyboard fix, water damage recovery. 90-day warranty. Serving Guildford, Woking, Godalming and Farnham.",
-        "url": "https://onlinefix.co.uk/macbook-repair.html",
+        "name": "iPad & Tablet Repair Guildford | Screen & Battery Fix Surrey",
+        "description": "No fix, no fee iPad and tablet repair in Guildford, Surrey. Same-day iPad screen replacement, battery swap, charging port fix, water damage recovery. 90-day warranty. Serving Guildford, Woking, Godalming and Farnham.",
+        "url": "https://onlinefix.co.uk/tablet-repair.html",
         "isPartOf": {
             "@type": "WebSite",
             "name": "OnlineFix",
@@ -108,18 +108,18 @@
             "itemListElement": [
                 {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://onlinefix.co.uk/"},
                 {"@type": "ListItem", "position": 2, "name": "Services", "item": "https://onlinefix.co.uk/services.html"},
-                {"@type": "ListItem", "position": 3, "name": "MacBook Repair", "item": "https://onlinefix.co.uk/macbook-repair.html"}
+                {"@type": "ListItem", "position": 3, "name": "Tablet Repair", "item": "https://onlinefix.co.uk/tablet-repair.html"}
             ]
         }
     }
     </script>
 
-    <!-- Service Schema - MacBook Repair -->
+    <!-- Service Schema - Tablet Repair -->
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
         "@type": "Service",
-        "serviceType": "MacBook Repair",
+        "serviceType": "Tablet Repair",
         "provider": {
             "@type": "LocalBusiness",
             "@id": "https://onlinefix.co.uk/#organization",
@@ -133,54 +133,54 @@
         ],
         "hasOfferCatalog": {
             "@type": "OfferCatalog",
-            "name": "MacBook Repair Services",
+            "name": "Tablet Repair Services",
             "itemListElement": [
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Logic Board Repair",
-                        "description": "Professional board-level repair for MacBook Pro and MacBook Air with no power, no backlight, kernel panics, or GPU failure using micro-soldering"
+                        "name": "Tablet Screen Replacement",
+                        "description": "Professional iPad and tablet screen replacement for cracked, unresponsive or black display screens on all iPad and Samsung Galaxy Tab models"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Screen Replacement",
-                        "description": "LCD and Retina display replacement for cracked, dead pixel, or flickering MacBook screens including MacBook Pro and MacBook Air models"
+                        "name": "Tablet Battery Replacement",
+                        "description": "High-capacity battery replacement for iPads and tablets with poor battery life, swollen batteries, or unexpected shutdowns"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Battery Replacement",
-                        "description": "Genuine-spec battery replacement for MacBook Pro and MacBook Air with swollen battery, poor battery life, or not charging issues"
+                        "name": "Tablet Charging Port Repair",
+                        "description": "Lightning and USB-C charging port replacement for iPads and tablets that won't charge, have loose connections, or intermittent charging"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Keyboard Repair",
-                        "description": "Keyboard replacement and repair for stuck, unresponsive, or butterfly mechanism MacBook keyboards including top case replacement"
+                        "name": "Tablet Water Damage Repair",
+                        "description": "Liquid damage diagnosis and board-level repair for water-damaged iPads and tablets with ultrasonic cleaning and component replacement"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook SSD Upgrade & Data Recovery",
-                        "description": "SSD storage upgrade and data recovery for MacBook Pro and MacBook Air, including transfer from failing drives"
+                        "name": "Tablet Button & Speaker Repair",
+                        "description": "Home button, power button, volume button, and speaker replacement for iPads and tablets with unresponsive controls or audio issues"
                     }
                 },
                 {
                     "@type": "Offer",
                     "itemOffered": {
                         "@type": "Service",
-                        "name": "MacBook Water Damage Repair",
-                        "description": "Liquid damage diagnosis and board-level repair for MacBook Pro and MacBook Air with corrosion cleaning and component replacement"
+                        "name": "Tablet Software & Performance Fix",
+                        "description": "Software troubleshooting, iOS and Android updates, factory resets, and performance optimisation for slow or unresponsive tablets"
                     }
                 }
             ]
@@ -188,7 +188,7 @@
     }
     </script>
 
-    <!-- FAQ Schema - MacBook Repair -->
+    <!-- FAQ Schema - Tablet Repair -->
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
@@ -196,50 +196,50 @@
         "mainEntity": [
             {
                 "@type": "Question",
-                "name": "How much does a MacBook screen replacement cost in Guildford?",
+                "name": "How much does an iPad screen replacement cost in Guildford?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "MacBook screen replacement at OnlineFix Guildford starts from £149 depending on the model. MacBook Air screens are typically less expensive than MacBook Pro Retina displays. The price includes the replacement display, professional fitting, and full testing. We operate a no fix, no fee policy and all repairs include a 90-day warranty."
+                    "text": "iPad screen replacement at OnlineFix Guildford starts from £55 and varies by model. Older iPads and iPad Mini models are at the lower end, while iPad Pro 12.9-inch with Liquid Retina XDR displays cost more due to the larger panel and advanced technology. The price includes the replacement screen, professional fitting, and full testing. We operate a no fix, no fee policy and all repairs include a 90-day warranty."
                 }
             },
             {
                 "@type": "Question",
-                "name": "Can you fix a MacBook that won't turn on?",
+                "name": "How long does a tablet repair take?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes. A MacBook that won't turn on is usually caused by a faulty logic board, failed power IC, liquid damage, or a dead battery. At OnlineFix we diagnose the exact cause with board-level testing equipment and only charge for the specific repair needed. Most power-related MacBook repairs are completed within 24-48 hours."
+                    "text": "Most iPad and tablet screen replacements are completed within 1-2 hours. Battery replacements take around 45-60 minutes due to the adhesive used in tablet construction. Charging port repairs are typically done within 1-2 hours. Water damage recovery may take longer depending on the extent of corrosion. We always provide a time estimate when you book your drop-off."
                 }
             },
             {
                 "@type": "Question",
-                "name": "Do you repair water-damaged MacBooks?",
+                "name": "Will my data be safe during the tablet repair?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes, we specialise in MacBook liquid damage repair. We perform ultrasonic cleaning of the logic board, replace corroded components using micro-soldering, and restore full functionality. The sooner you bring it in after a spill, the better the chances of a full recovery. No fix, no fee — if we can't save it, you don't pay."
+                    "text": "Yes, your data remains completely untouched during repair. We never access, wipe, or modify your personal data. For screen and battery replacements, your tablet keeps all its photos, apps, and files. For water damage repairs, data preservation is our priority throughout the recovery process. We recommend an iCloud or Google backup before any repair as best practice."
                 }
             },
             {
                 "@type": "Question",
-                "name": "How long does a MacBook repair take?",
+                "name": "Do you repair Samsung tablets as well as iPads?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Most MacBook repairs at OnlineFix Guildford are completed same-day or within 1-3 days. Battery and SSD swaps are typically same-day. Screen replacements and keyboard repairs take 24-48 hours. Logic board repairs may take 2-3 days for thorough diagnosis and testing. Unlike Apple Store or chains who send MacBooks away for weeks, we repair on-site in Guildford."
+                    "text": "Yes, we repair both Apple iPads and Samsung Galaxy Tab devices. This includes the Samsung Galaxy Tab S series and Galaxy Tab A series. We carry out screen replacements, battery swaps, charging port repairs, and more on Samsung tablets. Call us to book a drop-off and we will confirm parts availability for your specific model."
                 }
             },
             {
                 "@type": "Question",
-                "name": "Is it worth repairing an old MacBook?",
+                "name": "Is there a warranty on tablet repairs?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Often yes. An SSD upgrade and battery replacement can make a 2015-2019 MacBook feel brand new for a fraction of the cost of a replacement. We provide honest advice — if a repair doesn't make economic sense, we'll tell you upfront during our free diagnosis. No fix, no fee means zero risk to you."
+                    "text": "Yes, every tablet repair at OnlineFix comes with a 90-day warranty as standard. We stand behind every repair and use quality replacement parts. If the same issue recurs within the warranty period, we fix it at no additional cost. We also operate a no fix, no fee policy — there is no diagnostic fee and no risk to you."
                 }
             },
             {
                 "@type": "Question",
-                "name": "Is there a warranty on MacBook repairs?",
+                "name": "Can you fix a cracked iPad that still works?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes, all MacBook repairs at OnlineFix come with a 90-day warranty. We also operate a no fix, no fee policy — if we can't repair your MacBook, you don't pay. We stand behind our work and use quality replacement parts. If the same issue recurs within the 90-day warranty period, we'll fix it at no additional cost."
+                    "text": "Absolutely. Even if your iPad still functions with a cracked screen, we strongly recommend getting it repaired. Cracks can spread, sharp edges can cut your fingers, and moisture or dust can enter through the cracks and cause further internal damage. We replace the digitiser and LCD or Liquid Retina panel as needed, restoring your iPad to like-new condition with a 90-day warranty."
                 }
             }
         ]
@@ -287,7 +287,7 @@
 
         /* PAGE HEADER */
         .page-header { padding: 60px 0 0; background: linear-gradient(90deg, var(--hex-grid) 1px, transparent 1px) 0 0, linear-gradient(180deg, var(--hex-grid) 1px, transparent 1px) 0 0; background-size: 40px 40px; background-color: var(--hex-concrete); position: relative; overflow: hidden; }
-        .page-header::before { content: "FIG. 08 — MACBOOK REPAIR MANUAL"; position: absolute; top: 80px; left: 20px; font-family: monospace; font-size: 0.7rem; color: var(--hex-black); opacity: 0.6; }
+        .page-header::before { content: "FIG. 10 — TABLET REPAIR MANUAL"; position: absolute; top: 80px; left: 20px; font-family: monospace; font-size: 0.7rem; color: var(--hex-black); opacity: 0.6; }
         .page-header-content { max-width: 1400px; margin: 0 auto; padding: 4rem 20px; position: relative; z-index: 2; }
         .page-header-box { text-align: center; border: 2px solid var(--hex-black); padding: 3rem 4rem; background: var(--hex-white); box-shadow: 15px 15px 0px var(--hex-black); }
         .page-title { font-size: clamp(2rem, 6vw, 4rem); font-weight: 900; line-height: 0.9; text-transform: uppercase; letter-spacing: -2px; color: var(--hex-black); margin-bottom: 1rem; }
@@ -540,8 +540,8 @@
     <header class="page-header">
         <div class="page-header-content">
             <div class="page-header-box fade-in">
-                <h1 class="page-title">MACBOOK <span>REPAIR</span> GUILDFORD</h1>
-                <p class="page-subtitle">Same-Day MacBook Pro &amp; Air Repair // No Fix, No Fee // 90-Day Warranty</p>
+                <h1 class="page-title">IPAD &amp; TABLET <span>REPAIR</span> GUILDFORD</h1>
+                <p class="page-subtitle">Same-Day iPad &amp; Tablet Screen &amp; Battery Repair // No Fix, No Fee // 90-Day Warranty</p>
             </div>
         </div>
     </header>
@@ -551,28 +551,27 @@
         <section class="models-section" aria-labelledby="models-heading">
             <div class="container">
                 <h2 class="section-title fade-in" id="models-heading">"MODELS WE REPAIR"</h2>
-                <p class="section-subtitle fade-in">Every MacBook Generation Supported</p>
-                <div class="scroll-hint" aria-hidden="true">SCROLL &rarr;</div>
+                <p class="section-subtitle fade-in">Every iPad &amp; Tablet Generation Supported</p>
                 <div class="models-grid">
                     <div class="model-item fade-in">
-                        <div class="model-icon"><i class="fas fa-laptop" aria-hidden="true"></i></div>
-                        <div class="model-name">MacBook Pro</div>
-                        <div class="model-years">2012 &ndash; 2024 (Intel &amp; M-Series)</div>
+                        <div class="model-icon"><i class="fas fa-tablet-alt" aria-hidden="true"></i></div>
+                        <div class="model-name">iPad Pro (11" &amp; 12.9")</div>
+                        <div class="model-years">M1 / M2 / M4</div>
                     </div>
                     <div class="model-item fade-in">
-                        <div class="model-icon"><i class="fas fa-laptop" aria-hidden="true"></i></div>
-                        <div class="model-name">MacBook Air</div>
-                        <div class="model-years">2013 &ndash; 2024 (Intel &amp; M-Series)</div>
+                        <div class="model-icon"><i class="fas fa-tablet-alt" aria-hidden="true"></i></div>
+                        <div class="model-name">iPad Air / iPad 10th Gen</div>
+                        <div class="model-years">All Generations</div>
                     </div>
                     <div class="model-item fade-in">
-                        <div class="model-icon"><i class="fas fa-laptop" aria-hidden="true"></i></div>
-                        <div class="model-name">MacBook 12&quot;</div>
-                        <div class="model-years">2015 &ndash; 2017 (Retina)</div>
+                        <div class="model-icon"><i class="fas fa-tablet-alt" aria-hidden="true"></i></div>
+                        <div class="model-name">iPad Mini</div>
+                        <div class="model-years">All Generations</div>
                     </div>
                     <div class="model-item fade-in">
-                        <div class="model-icon"><i class="fas fa-desktop" aria-hidden="true"></i></div>
-                        <div class="model-name">iMac / Mac Mini</div>
-                        <div class="model-years">Select Models Supported</div>
+                        <div class="model-icon"><i class="fas fa-tablet-alt" aria-hidden="true"></i></div>
+                        <div class="model-name">Samsung Galaxy Tab</div>
+                        <div class="model-years">S Series &amp; A Series</div>
                     </div>
                 </div>
             </div>
@@ -582,150 +581,149 @@
         <section class="issues-section" aria-labelledby="issues-heading">
             <div class="container">
                 <h2 class="section-title fade-in" id="issues-heading">"COMMON ISSUES WE FIX"</h2>
-                <p class="section-subtitle fade-in">Board-Level Micro-Soldering &amp; Component Repair</p>
-                <div class="scroll-hint" aria-hidden="true">SCROLL &rarr;</div>
+                <p class="section-subtitle fade-in">Expert Diagnosis &amp; Professional Tablet Repair</p>
                 <div class="issues-grid">
-                    <!-- LOGIC BOARD REPAIR -->
+                    <!-- SCREEN REPLACEMENT -->
                     <article class="issue-card fade-in" data-issue-num="ISSUE_01">
                         <div class="issue-header">
-                            <div class="issue-icon"><i class="fas fa-microchip" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">Logic Board Repair</h3>
-                        </div>
-                        <p class="issue-description">The logic board is the brain of your MacBook. Failed power ICs, blown capacitors, GPU faults, and short circuits can all cause a dead or malfunctioning machine. We perform board-level micro-soldering to diagnose and replace the specific failed components — saving your MacBook when Apple says it needs a full replacement.</p>
-                        <p class="issue-subtitle">Symptoms:</p>
-                        <ul class="issue-symptoms">
-                            <li>MacBook completely dead — no power, no light</li>
-                            <li>Turns on but no display (backlight failure)</li>
-                            <li>Random kernel panics and crashes</li>
-                            <li>USB-C / Thunderbolt ports not working</li>
-                            <li>Fan spinning at full speed constantly</li>
-                        </ul>
-                        <div class="issue-bottom">
-                            <div class="issue-pricing">
-                                <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;95</div>
-                            </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Board Repair</a>
-                        </div>
-                    </article>
-
-                    <!-- SCREEN REPLACEMENT -->
-                    <article class="issue-card fade-in" data-issue-num="ISSUE_02">
-                        <div class="issue-header">
-                            <div class="issue-icon"><i class="fas fa-desktop" aria-hidden="true"></i></div>
+                            <div class="issue-icon"><i class="fas fa-tablet-alt" aria-hidden="true"></i></div>
                             <h3 class="issue-title">Screen Replacement</h3>
                         </div>
-                        <p class="issue-description">Cracked glass, dead pixels, vertical lines, or a completely black display — we replace MacBook screens with quality Retina-grade panels. Whether it's a MacBook Pro 13&quot;, 14&quot;, 15&quot;, or 16&quot;, or a MacBook Air, we have screens in stock for most models and complete the swap with precise calibration.</p>
+                        <p class="issue-description">The most common tablet repair. Cracked glass, unresponsive touch, or a black display — we replace your iPad or tablet screen with a high-quality LCD or Liquid Retina panel matched to your model. Tablet screens are larger and more delicate than phone screens, requiring specialist tools and precision. Every replacement is tested for colour accuracy, touch sensitivity, and Apple Pencil compatibility before collection.</p>
                         <p class="issue-subtitle">Symptoms:</p>
                         <ul class="issue-symptoms">
-                            <li>Cracked or shattered display glass</li>
-                            <li>Vertical coloured lines across the screen</li>
-                            <li>Black screen but MacBook sounds on</li>
-                            <li>Flickering or dim display</li>
-                            <li>Dead pixels or discoloured patches</li>
+                            <li>Cracked or shattered front glass</li>
+                            <li>Touch screen unresponsive or ghost touches</li>
+                            <li>Black screen but tablet vibrates or makes sounds</li>
+                            <li>Lines or dead zones across the display</li>
+                            <li>Apple Pencil not registering on screen</li>
                         </ul>
                         <div class="issue-bottom">
                             <div class="issue-pricing">
                                 <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;149</div>
+                                <div class="issue-price">&pound;55</div>
                             </div>
                             <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Screen Repair</a>
                         </div>
                     </article>
 
                     <!-- BATTERY REPLACEMENT -->
-                    <article class="issue-card fade-in" data-issue-num="ISSUE_03">
+                    <article class="issue-card fade-in" data-issue-num="ISSUE_02">
                         <div class="issue-header">
                             <div class="issue-icon"><i class="fas fa-battery-quarter" aria-hidden="true"></i></div>
                             <h3 class="issue-title">Battery Replacement</h3>
                         </div>
-                        <p class="issue-description">MacBook batteries degrade over time — after 500-1000 charge cycles, capacity drops significantly. Swollen batteries are a safety hazard that can warp the trackpad or case. We replace batteries with high-quality cells that restore your MacBook to full-day battery life. Most battery swaps are completed same-day.</p>
+                        <p class="issue-description">Tablet batteries are much larger than phone batteries but still degrade over time. After hundreds of charge cycles, your iPad or Samsung tablet may struggle to hold a charge through a single film or work session. We carefully remove the adhesive-bonded battery and fit a high-quality replacement cell, restoring your tablet to full all-day battery life.</p>
                         <p class="issue-subtitle">Symptoms:</p>
                         <ul class="issue-symptoms">
-                            <li>"Service Battery" or "Replace Soon" warning</li>
-                            <li>Battery drains in under 2 hours</li>
-                            <li>Swollen/bulging trackpad or bottom case</li>
-                            <li>MacBook only works when plugged in</li>
-                            <li>Random shutdowns at 20-40% battery</li>
+                            <li>Battery drains within a few hours of use</li>
+                            <li>Tablet shuts down unexpectedly at 20-30%</li>
+                            <li>Battery health below 80% in Settings</li>
+                            <li>Tablet takes excessively long to charge</li>
+                            <li>Swollen battery causing screen to lift or bulge</li>
                         </ul>
                         <div class="issue-bottom">
                             <div class="issue-pricing">
                                 <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;79</div>
+                                <div class="issue-price">&pound;45</div>
                             </div>
                             <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Battery Swap</a>
                         </div>
                     </article>
 
-                    <!-- KEYBOARD REPAIR -->
-                    <article class="issue-card fade-in" data-issue-num="ISSUE_04">
+                    <!-- CHARGING PORT -->
+                    <article class="issue-card fade-in" data-issue-num="ISSUE_03">
                         <div class="issue-header">
-                            <div class="issue-icon"><i class="fas fa-keyboard" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">Keyboard Repair</h3>
+                            <div class="issue-icon"><i class="fas fa-plug" aria-hidden="true"></i></div>
+                            <h3 class="issue-title">Charging Port Repair</h3>
                         </div>
-                        <p class="issue-description">The infamous butterfly keyboard (2016-2019 MacBook Pro) is notorious for stuck and unresponsive keys. Even scissor-switch keyboards on newer models can fail from dust or liquid ingress. We replace faulty keyboards — including full top case swaps when needed — restoring every key to reliable operation.</p>
+                        <p class="issue-description">A faulty Lightning or USB-C port is a common tablet issue — lint buildup, bent pins, or a worn connector can prevent your iPad or tablet from charging. Because tablets are often charged on sofas and beds, debris accumulates faster than on phones. We replace the entire charge port assembly, restoring reliable charging and data transfer.</p>
                         <p class="issue-subtitle">Symptoms:</p>
                         <ul class="issue-symptoms">
-                            <li>Keys stuck, mushy, or unresponsive</li>
-                            <li>Double-typing or ghost key presses</li>
-                            <li>Backlight not working on some keys</li>
-                            <li>Spacebar or shift key intermittent</li>
-                            <li>Keys physically missing or broken</li>
+                            <li>Tablet won't charge or charges intermittently</li>
+                            <li>Cable feels loose or falls out of the port</li>
+                            <li>Only charges at certain angles</li>
+                            <li>Tablet not recognised when connected to computer</li>
+                            <li>"Accessory not supported" error message</li>
                         </ul>
                         <div class="issue-bottom">
                             <div class="issue-pricing">
                                 <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;89</div>
+                                <div class="issue-price">&pound;45</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Keyboard Fix</a>
-                        </div>
-                    </article>
-
-                    <!-- SSD UPGRADE & DATA RECOVERY -->
-                    <article class="issue-card fade-in" data-issue-num="ISSUE_05">
-                        <div class="issue-header">
-                            <div class="issue-icon"><i class="fas fa-hdd" aria-hidden="true"></i></div>
-                            <h3 class="issue-title">SSD Upgrade &amp; Data Recovery</h3>
-                        </div>
-                        <p class="issue-description">Running out of storage or stuck on a slow spinning hard drive? We upgrade older MacBooks to fast NVMe SSDs — making them feel like new machines. For failing drives, we recover your data before it's lost. We handle everything from 128GB to 2TB upgrades, including OS migration so you're back up and running immediately.</p>
-                        <p class="issue-subtitle">Symptoms:</p>
-                        <ul class="issue-symptoms">
-                            <li>"Startup disk almost full" warnings</li>
-                            <li>Extremely slow boot times (spinning wheel)</li>
-                            <li>Apps freezing or beach-balling constantly</li>
-                            <li>Clicking noises from hard drive</li>
-                            <li>Files disappearing or corrupted</li>
-                        </ul>
-                        <div class="issue-bottom">
-                            <div class="issue-pricing">
-                                <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;69</div>
-                            </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book SSD Upgrade</a>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Port Repair</a>
                         </div>
                     </article>
 
                     <!-- WATER DAMAGE -->
-                    <article class="issue-card fade-in" data-issue-num="ISSUE_06">
+                    <article class="issue-card fade-in" data-issue-num="ISSUE_04">
                         <div class="issue-header">
                             <div class="issue-icon"><i class="fas fa-tint" aria-hidden="true"></i></div>
                             <h3 class="issue-title">Water Damage Repair</h3>
                         </div>
-                        <p class="issue-description">Spilled coffee, tea, or water on your MacBook? Time is critical. Liquid causes corrosion that spreads across the logic board within hours. We perform ultrasonic cleaning to remove all corrosion, then diagnose and replace any damaged components using micro-soldering. The sooner you bring it in, the better the recovery chances.</p>
+                        <p class="issue-description">Tablets are frequently used in kitchens, bathrooms, and by the pool — making liquid damage a common problem. Unlike iPhones, most iPads and tablets have no water resistance rating at all. Spilled drinks, rain, and steam exposure can all cause serious internal corrosion. We perform ultrasonic cleaning of the logic board, replace corroded components, and work to restore full functionality. Time is critical — the sooner you bring it in, the better.</p>
                         <p class="issue-subtitle">Symptoms:</p>
                         <ul class="issue-symptoms">
-                            <li>MacBook dead after liquid spill</li>
-                            <li>Keyboard keys sticking or not working</li>
-                            <li>Trackpad clicking on its own</li>
-                            <li>Screen flickering or discoloured</li>
-                            <li>Charging intermittent or not working</li>
+                            <li>Tablet dead after liquid exposure</li>
+                            <li>Screen flickering or showing discolouration</li>
+                            <li>Speakers muffled, crackling, or silent</li>
+                            <li>Erratic touch behaviour after getting wet</li>
+                            <li>Tablet overheating or refusing to charge</li>
                         </ul>
                         <div class="issue-bottom">
                             <div class="issue-pricing">
                                 <div class="price-text">Starting From</div>
-                                <div class="issue-price">&pound;85</div>
+                                <div class="issue-price">&pound;65</div>
                             </div>
                             <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Water Damage Repair</a>
+                        </div>
+                    </article>
+
+                    <!-- BUTTON & SPEAKER REPAIR -->
+                    <article class="issue-card fade-in" data-issue-num="ISSUE_05">
+                        <div class="issue-header">
+                            <div class="issue-icon"><i class="fas fa-volume-up" aria-hidden="true"></i></div>
+                            <h3 class="issue-title">Button &amp; Speaker Repair</h3>
+                        </div>
+                        <p class="issue-description">Physical buttons and speakers on tablets endure heavy daily use. A stuck home button, unresponsive power button, or blown speaker can seriously impact your tablet experience — especially if you rely on it for video calls, media, or as a second screen. We replace faulty button flex cables and speaker modules to restore full functionality.</p>
+                        <p class="issue-subtitle">Symptoms:</p>
+                        <ul class="issue-symptoms">
+                            <li>Home button not clicking or unresponsive</li>
+                            <li>Power or volume buttons stuck or mushy</li>
+                            <li>No sound from one or both speakers</li>
+                            <li>Distorted or crackling audio during playback</li>
+                            <li>Microphone not working on video calls</li>
+                        </ul>
+                        <div class="issue-bottom">
+                            <div class="issue-pricing">
+                                <div class="price-text">Starting From</div>
+                                <div class="issue-price">&pound;35</div>
+                            </div>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Button / Speaker Repair</a>
+                        </div>
+                    </article>
+
+                    <!-- SOFTWARE & PERFORMANCE -->
+                    <article class="issue-card fade-in" data-issue-num="ISSUE_06">
+                        <div class="issue-header">
+                            <div class="issue-icon"><i class="fas fa-cog" aria-hidden="true"></i></div>
+                            <h3 class="issue-title">Software &amp; Performance</h3>
+                        </div>
+                        <p class="issue-description">Older iPads and tablets can slow down significantly after major software updates, or become stuck in boot loops and recovery mode. We diagnose and resolve software issues including frozen screens, disabled tablets, forgotten passcodes, and performance degradation. If your tablet feels sluggish or is stuck on the Apple logo, we can help get it running smoothly again.</p>
+                        <p class="issue-subtitle">Symptoms:</p>
+                        <ul class="issue-symptoms">
+                            <li>Tablet extremely slow or freezing constantly</li>
+                            <li>Stuck on Apple logo or boot loop</li>
+                            <li>iPad disabled after too many passcode attempts</li>
+                            <li>Apps crashing or failing to open</li>
+                            <li>Tablet stuck in recovery or DFU mode</li>
+                        </ul>
+                        <div class="issue-bottom">
+                            <div class="issue-pricing">
+                                <div class="price-text">Starting From</div>
+                                <div class="issue-price">&pound;25</div>
+                            </div>
+                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Software Fix</a>
                         </div>
                     </article>
                 </div>
@@ -735,8 +733,8 @@
         <!-- Emergency CTA -->
         <section class="emergency-section" aria-label="Emergency repair contact">
             <div class="container">
-                <h2>"MACBOOK DOWN?"</h2>
-                <p>Don't replace it — repair it. Same-day service available. Free diagnosis. No fix, no fee. Call to book a drop-off.</p>
+                <h2>"TABLET BROKEN?"</h2>
+                <p>Don't overpay at Apple — get it fixed fast. Same-day repairs available. Free diagnosis. No fix, no fee. Call to book a drop-off.</p>
                 <a href="tel:+447940730537" class="emergency-btn">
                     <i class="fas fa-phone-alt" aria-hidden="true"></i> Call to Book — 07940 730537
                 </a>
@@ -747,17 +745,17 @@
         <section class="why-section" aria-labelledby="why-heading">
             <div class="container">
                 <h2 class="section-title fade-in" id="why-heading">"WHY CHOOSE ONLINEFIX?"</h2>
-                <p class="section-subtitle fade-in">Board-Level Repair. Not Just Part Swapping.</p>
+                <p class="section-subtitle fade-in">Fast, Affordable, Professional Tablet Repair</p>
                 <div class="why-grid">
                     <div class="why-item fade-in">
                         <div class="why-icon"><i class="fas fa-shield-alt" aria-hidden="true"></i></div>
                         <div class="why-title">No Fix, No Fee</div>
-                        <p class="why-description">If we can't repair your MacBook, you don't pay a penny. Zero risk — we only charge for successful repairs.</p>
+                        <p class="why-description">If we can't repair your tablet, you don't pay a penny. Zero risk — we only charge for successful repairs.</p>
                     </div>
                     <div class="why-item fade-in">
                         <div class="why-icon"><i class="fas fa-bolt" aria-hidden="true"></i></div>
                         <div class="why-title">Same-Day Repairs</div>
-                        <p class="why-description">Battery swaps and SSD upgrades done same-day. Unlike Apple Store who quote 5-7 business days, we repair on-site in Guildford.</p>
+                        <p class="why-description">Most tablet screen and battery repairs completed same day. Unlike the Apple Store who quote 3-5 business days, we repair while you wait.</p>
                     </div>
                     <div class="why-item fade-in">
                         <div class="why-icon"><i class="fas fa-certificate" aria-hidden="true"></i></div>
@@ -765,9 +763,9 @@
                         <p class="why-description">Every repair backed by our 90-day warranty. If the same fault returns within 90 days, we fix it again completely free.</p>
                     </div>
                     <div class="why-item fade-in">
-                        <div class="why-icon"><i class="fas fa-microchip" aria-hidden="true"></i></div>
-                        <div class="why-title">Board-Level Repair</div>
-                        <p class="why-description">We micro-solder individual components — saving your MacBook when Apple says "replace the whole board" for &pound;500+.</p>
+                        <div class="why-icon"><i class="fas fa-calendar-check" aria-hidden="true"></i></div>
+                        <div class="why-title">Easy Scheduled Drop-Off</div>
+                        <p class="why-description">Book a convenient drop-off time at our Guildford workshop. Open 10am&ndash;10pm, 7 days a week. Serving Woking, Godalming &amp; Farnham too.</p>
                     </div>
                 </div>
                 <div class="why-vs fade-in">
@@ -775,11 +773,11 @@
                     <div class="why-vs-row">
                         <div class="why-vs-col">
                             <div class="why-vs-label">OnlineFix</div>
-                            <div class="why-vs-value highlight">Board-level repair from &pound;79<br>Same-day for most repairs<br>No fix, no fee<br>90-day warranty<br>Easy scheduled drop-offs</div>
+                            <div class="why-vs-value highlight">Screen repair from &pound;55<br>Same-day, often under 2 hours<br>No fix, no fee<br>90-day warranty<br>Easy scheduled drop-offs</div>
                         </div>
                         <div class="why-vs-col">
                             <div class="why-vs-label">Apple Store / Others</div>
-                            <div class="why-vs-value">"Replace entire board" from &pound;500+<br>5-7 business days minimum<br>Diagnostic fees charged upfront<br>Limited warranty on parts only<br>Long wait for appointments</div>
+                            <div class="why-vs-value">Screen repair from &pound;200+<br>3-5 business days minimum<br>Diagnostic fees charged upfront<br>Limited warranty on parts only<br>Long wait for appointments</div>
                         </div>
                     </div>
                 </div>
@@ -790,12 +788,12 @@
         <section class="process-section" aria-labelledby="process-heading">
             <div class="container">
                 <h2 class="section-title fade-in" id="process-heading">"HOW IT WORKS"</h2>
-                <p class="section-subtitle fade-in">Drop Off &rarr; Diagnose &rarr; Repair &rarr; Collect</p>
+                <p class="section-subtitle fade-in">Book &rarr; Drop Off &rarr; Repair &rarr; Collect</p>
                 <div class="process-grid">
                     <div class="process-item fade-in">
                         <div class="process-number">01</div>
                         <h4>Free Diagnosis</h4>
-                        <p>Call us or describe the issue over the phone. Book a drop-off and we diagnose the fault at no cost — including board-level testing.</p>
+                        <p>Call us or send a message describing the issue. Book a convenient drop-off time and we diagnose the fault at no cost.</p>
                     </div>
                     <div class="process-item fade-in">
                         <div class="process-number">02</div>
@@ -805,12 +803,12 @@
                     <div class="process-item fade-in">
                         <div class="process-number">03</div>
                         <h4>Expert Repair</h4>
-                        <p>Professional micro-soldering and component-level repair using quality parts. Your data stays safe throughout — we never wipe without asking.</p>
+                        <p>Professional repair using quality OEM-spec parts. Your data stays completely safe — we never access or wipe your tablet.</p>
                     </div>
                     <div class="process-item fade-in">
                         <div class="process-number">04</div>
                         <h4>Tested &amp; Returned</h4>
-                        <p>Every repair is stress-tested with diagnostics before collection. Your MacBook comes back working perfectly, with a 90-day warranty.</p>
+                        <p>Every repair is fully tested — screen, touch, cameras, sensors, charging — before collection. 90-day warranty included.</p>
                     </div>
                 </div>
             </div>
@@ -820,42 +818,42 @@
         <section class="faq-section" aria-labelledby="faq-heading">
             <div class="container">
                 <h2 class="section-title fade-in" id="faq-heading">"FAQ"</h2>
-                <p class="section-subtitle fade-in">Common Questions About MacBook Repair</p>
+                <p class="section-subtitle fade-in">Common Questions About Tablet Repair</p>
                 <div class="faq-list">
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">How much does a MacBook screen replacement cost in Guildford?</button>
+                        <button class="faq-question" aria-expanded="false">How much does an iPad screen replacement cost in Guildford?</button>
                         <div class="faq-answer" role="region">
-                            <p>MacBook screen replacement at OnlineFix Guildford starts from &pound;149 depending on the model. MacBook Air screens are typically less expensive than MacBook Pro Retina displays. The price includes the replacement display, professional fitting, and full testing. We operate a <strong>no fix, no fee</strong> policy and all repairs include a <strong>90-day warranty</strong>.</p>
+                            <p>iPad screen replacement at OnlineFix Guildford starts from &pound;55 and varies by model. Older iPads and iPad Mini models are at the lower end, while iPad Pro 12.9-inch models with Liquid Retina XDR displays cost more due to the larger panel and advanced technology. Every price includes the replacement screen, professional fitting, and full testing. We operate a <strong>no fix, no fee</strong> policy and all repairs include a <strong>90-day warranty</strong>.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">Can you fix a MacBook that won't turn on?</button>
+                        <button class="faq-question" aria-expanded="false">How long does a tablet repair take?</button>
                         <div class="faq-answer" role="region">
-                            <p>Yes. A MacBook that won't turn on is usually caused by a faulty logic board, failed power IC, liquid damage, or a dead battery. At OnlineFix Guildford, we diagnose the exact cause with board-level testing equipment and only charge for the specific repair needed. Our <strong>no fix, no fee</strong> policy means you won't pay if we can't resolve it, and all repairs include a <strong>90-day warranty</strong>. Most power-related MacBook repairs are completed within <strong>24-48 hours</strong>.</p>
+                            <p>Most iPad and tablet screen replacements are completed within <strong>1-2 hours</strong>. Battery replacements take around 45-60 minutes due to the strong adhesive used in tablet construction. Charging port repairs are typically done within 1-2 hours. Water damage recovery may take longer depending on the extent of corrosion. We always provide a time estimate when you <strong>book your drop-off</strong>.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">Do you repair water-damaged MacBooks?</button>
+                        <button class="faq-question" aria-expanded="false">Will my data be safe during the repair?</button>
                         <div class="faq-answer" role="region">
-                            <p>Yes, we specialise in MacBook liquid damage repair. We perform ultrasonic cleaning of the logic board, replace corroded components using micro-soldering, and restore full functionality. The sooner you bring it in after a spill, the better the chances. <strong>No fix, no fee</strong> — if we can't save it, you don't pay. <strong>Call to book your drop-off</strong> at our Guildford shop.</p>
+                            <p>Yes, your data remains <strong>completely untouched</strong> during repair. We never access, wipe, or modify your personal data. For screen and battery replacements, your tablet keeps all its photos, apps, and files. For water damage repairs, data preservation is our priority throughout the recovery process. We recommend an iCloud or Google backup before any repair as best practice.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">How long does a MacBook repair take?</button>
+                        <button class="faq-question" aria-expanded="false">Do you repair Samsung tablets as well as iPads?</button>
                         <div class="faq-answer" role="region">
-                            <p>Most MacBook repairs are completed <strong>same-day or within 1-3 days</strong>. Battery swaps and SSD upgrades are typically same-day. Screen replacements and keyboard repairs take 24-48 hours. Logic board repairs may take 2-3 days for thorough testing. Unlike the Apple Store who quote 5-7 business days, we repair on-site in Guildford. Serving Guildford, Woking, Godalming, and Farnham.</p>
+                            <p>Yes, we repair both <strong>Apple iPads and Samsung Galaxy Tab</strong> devices. This includes the Samsung Galaxy Tab S series and Galaxy Tab A series. We carry out screen replacements, battery swaps, charging port repairs, and more on Samsung tablets. <strong>Call to book a drop-off</strong> and we will confirm parts availability for your specific model.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">Is it worth repairing an old MacBook?</button>
+                        <button class="faq-question" aria-expanded="false">Is there a warranty on tablet repairs?</button>
                         <div class="faq-answer" role="region">
-                            <p>Often yes. An SSD upgrade and battery replacement can make a 2015-2019 MacBook feel brand new for a fraction of the cost of a replacement. We provide honest advice — if a repair doesn't make economic sense, we'll tell you upfront during our <strong>free diagnosis</strong>. <strong>No fix, no fee</strong> means zero risk to you.</p>
+                            <p>Yes, every tablet repair at OnlineFix comes with a <strong>90-day warranty</strong> as standard. We stand behind every repair and use quality replacement parts. If the same issue recurs within the warranty period, we'll fix it at no additional cost. We also operate a <strong>no fix, no fee</strong> policy — there's no diagnostic fee and no risk to you.</p>
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">Is there a warranty on MacBook repairs?</button>
+                        <button class="faq-question" aria-expanded="false">Can you fix a cracked iPad that still works?</button>
                         <div class="faq-answer" role="region">
-                            <p>Yes, every MacBook repair at OnlineFix comes with a <strong>90-day warranty</strong> as standard. We stand behind every repair and use quality replacement components. If the same issue recurs within the warranty period, we'll fix it at no additional cost. We also operate a <strong>no fix, no fee</strong> policy — unlike the Apple Store, there's no diagnostic fee and no risk to you.</p>
+                            <p>Absolutely. Even if your iPad still functions with a cracked screen, we strongly recommend getting it repaired. Cracks can spread over time, sharp edges can cut your fingers, and moisture or dust can enter through the cracks causing further internal damage. We replace the digitiser and LCD or Liquid Retina panel as needed, restoring your iPad to like-new condition with a <strong>90-day warranty</strong>. <strong>Call to book your drop-off</strong> at our Guildford workshop.</p>
                         </div>
                     </div>
                 </div>
@@ -865,11 +863,11 @@
         <section style="padding: 3rem 0; border-top: 2px solid var(--hex-black); background: var(--hex-concrete);" aria-label="Other repair services">
             <div class="container">
                 <h2 style="font-size: clamp(1.3rem, 3vw, 1.8rem); font-weight: 900; text-transform: uppercase; text-align: center; margin-bottom: 0.5rem;">"OTHER SERVICES"</h2>
-                <p style="text-align: center; font-family: monospace; color: #666; font-size: 0.85rem; margin-bottom: 2rem; text-transform: uppercase;">We repair more than just MacBooks</p>
+                <p style="text-align: center; font-family: monospace; color: #666; font-size: 0.85rem; margin-bottom: 2rem; text-transform: uppercase;">We repair more than just tablets</p>
                 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; max-width: 900px; margin: 0 auto;">
                     <a href="iphone-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-mobile-alt" aria-hidden="true" style="color: var(--hex-accent);"></i> iPhone Repair</a>
                     <a href="console-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-gamepad" aria-hidden="true" style="color: var(--hex-accent);"></i> Console Repair</a>
-                    <a href="tablet-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-tablet-alt" aria-hidden="true" style="color: var(--hex-accent);"></i> Tablet Repair</a>
+                    <a href="macbook-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-laptop" aria-hidden="true" style="color: var(--hex-accent);"></i> MacBook Repair</a>
                     <a href="pc-repair.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-desktop" aria-hidden="true" style="color: var(--hex-accent);"></i> PC Repair</a>
                     <a href="data-recovery.html" style="display: flex; align-items: center; gap: 10px; padding: 1rem 1.2rem; background: var(--hex-white); border: 2px solid var(--hex-black); text-decoration: none; color: var(--hex-black); font-weight: 700; text-transform: uppercase; font-size: 0.85rem; transition: all 0.1s;"><i class="fas fa-hdd" aria-hidden="true" style="color: var(--hex-accent);"></i> Data Recovery</a>
                 </div>
@@ -883,7 +881,7 @@
             <div class="footer-grid">
                 <div class="footer-column">
                     <h4>"ONLINEFIX"</h4>
-                    <p style="font-family: monospace; color: #999;">Expert electronics &amp; MacBook repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
+                    <p style="font-family: monospace; color: #999;">Expert electronics &amp; tablet repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div class="social-links" style="margin-top: 1rem; font-size: 1.5rem;">
                         <a href="https://instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
                         <a href="https://tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
@@ -983,24 +981,6 @@
             el.style.animationPlayState = 'paused';
             fadeObserver.observe(el);
         });
-
-        // Mobile scroll nudge
-        if (window.innerWidth < 768) {
-            const scrollGrids = document.querySelectorAll('.issues-grid, .models-grid');
-            const nudgeObserver = new IntersectionObserver((entries) => {
-                entries.forEach(entry => {
-                    if (entry.isIntersecting) {
-                        const target = entry.target;
-                        setTimeout(() => {
-                            target.scrollBy({ left: 50, behavior: 'smooth' });
-                            setTimeout(() => { target.scrollBy({ left: -50, behavior: 'smooth' }); }, 800);
-                        }, 500);
-                        nudgeObserver.unobserve(target);
-                    }
-                });
-            }, { threshold: 0.6 });
-            scrollGrids.forEach(grid => nudgeObserver.observe(grid));
-        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
- Created tablet-repair.html (iPad & tablet repair, 6 issues, 4 models)
- Created pc-repair.html (desktop & gaming PC repair, 6 issues, 4 types)
- Created data-recovery.html (HDD, SSD, USB, phone recovery, 6 services)
- Added 3 new service cards to index.html (Tablets, PCs, Data Recovery)
- Added Tablet Repair, PC Repair, Data Recovery to all 11 page footers
- Added 3 new entries to sitemap.xml at 0.9 priority
- Added "Other Services" cross-link section to all 6 repair pages
- All pages: brutalist design, full schema, GA4, no walk-in language

https://claude.ai/code/session_01XV1EsGtMXsjRvELCmA4xzh