### PR TITLE
Fix Google indexing issues: schema URL redirects, meta tags, and sitemap

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,10 +14,12 @@
     <meta name="description" content="Learn about OnlineFix and Tomas, your trusted electronics repair expert in Guildford, Surrey. Years of experience in smartphone, laptop, tablet, and gaming console repairs with 5-star service.">
     <meta name="keywords" content="about OnlineFix, Tomas electronics repair, electronics repair technician Guildford, professional repair service Surrey, expert tech repair Guildford">
     <meta name="author" content="OnlineFix - Tomas">
-    <meta name="robots" content="index, follow">
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <link rel="canonical" href="https://onlinefix.co.uk/about.html">
+    <link rel="sitemap" type="application/xml" href="/sitemap.xml">
 
     <meta property="og:type" content="website">
+    <meta property="og:site_name" content="OnlineFix Guildford">
     <meta property="og:url" content="https://onlinefix.co.uk/about.html">
     <meta property="og:title" content="About OnlineFix - Meet Tomas, Expert Electronics Repair Technician">
     <meta property="og:description" content="Learn about OnlineFix and Tomas, your trusted electronics repair expert in Guildford, Surrey.">
@@ -72,7 +74,7 @@
         "isPartOf": {
             "@type": "WebSite",
             "name": "OnlineFix",
-            "url": "https://onlinefix.co.uk"
+            "url": "https://onlinefix.co.uk/"
         },
         "about": {
             "@type": "LocalBusiness",
@@ -478,8 +480,8 @@
                     <h4>"ONLINEFIX"</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div style="margin-top: 1rem; font-size: 1.5rem;">
-                        <a href="https://instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
-                        <a href="https://tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
+                        <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                        <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
                 </div>
                 <div class="footer-column">

--- a/console-repair.html
+++ b/console-repair.html
@@ -38,11 +38,11 @@
     <meta property="og:image:alt" content="OnlineFix Console Repair - PlayStation Xbox Nintendo Switch Repair Guildford">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://onlinefix.co.uk/console-repair.html">
-    <meta property="twitter:title" content="Console Repair Guildford | Same-Day Fix | No Fix No Fee">
-    <meta property="twitter:description" content="PS5, Xbox & Switch repair in Guildford. HDMI port fix, disk drive, overheating & power repair. Same-day service. 90-day warranty. Appointment only.">
-    <meta property="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://onlinefix.co.uk/console-repair.html">
+    <meta name="twitter:title" content="Console Repair Guildford | Same-Day Fix | No Fix No Fee">
+    <meta name="twitter:description" content="PS5, Xbox & Switch repair in Guildford. HDMI port fix, disk drive, overheating & power repair. Same-day service. 90-day warranty. Appointment only.">
+    <meta name="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" sizes="512x512" href="/favicon.png">
@@ -98,7 +98,7 @@
         "isPartOf": {
             "@type": "WebSite",
             "name": "OnlineFix",
-            "url": "https://onlinefix.co.uk"
+            "url": "https://onlinefix.co.uk/"
         },
         "about": {
             "@id": "https://onlinefix.co.uk/#organization"
@@ -858,8 +858,8 @@
                     <h4>"ONLINEFIX"</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics &amp; console repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div class="social-links" style="margin-top: 1rem; font-size: 1.5rem;">
-                        <a href="https://instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
-                        <a href="https://tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
+                        <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                        <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
                 </div>
                 <div class="footer-column">

--- a/contact.html
+++ b/contact.html
@@ -14,10 +14,12 @@
     <meta name="description" content="Contact OnlineFix for electronics repair in Guildford, Surrey. Call 07940 730537 or visit our workshop. Open 10 AM - 10 PM daily. Same-day repairs available.">
     <meta name="keywords" content="contact OnlineFix, electronics repair Guildford contact, phone repair contact Surrey, Tomas electronics repair contact, Guildford repair shop">
     <meta name="author" content="OnlineFix - Tomas">
-    <meta name="robots" content="index, follow">
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <link rel="canonical" href="https://onlinefix.co.uk/contact.html">
+    <link rel="sitemap" type="application/xml" href="/sitemap.xml">
 
     <meta property="og:type" content="website">
+    <meta property="og:site_name" content="OnlineFix Guildford">
     <meta property="og:url" content="https://onlinefix.co.uk/contact.html">
     <meta property="og:title" content="Contact OnlineFix - Electronics Repair in Guildford">
     <meta property="og:description" content="Contact OnlineFix for professional electronics repair in Guildford, Surrey. Call 07940 730537 for same-day service.">
@@ -72,7 +74,7 @@
         "isPartOf": {
             "@type": "WebSite",
             "name": "OnlineFix",
-            "url": "https://onlinefix.co.uk"
+            "url": "https://onlinefix.co.uk/"
         },
         "about": {
             "@type": "LocalBusiness",
@@ -461,8 +463,8 @@
             <div class="container">
                 <h2 class="section-title fade-in" id="social-heading" style="padding-top: 0;">FOLLOW US</h2>
                 <div class="social-links fade-in">
-                    <a href="https://instagram.com/onlinefixrepairs" class="social-link" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
-                    <a href="https://tiktok.com/@onlinefix" class="social-link" target="_blank" rel="noopener noreferrer" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
+                    <a href="https://www.instagram.com/onlinefixrepairs" class="social-link" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                    <a href="https://www.tiktok.com/@onlinefix" class="social-link" target="_blank" rel="noopener noreferrer" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     <a href="https://maps.app.goo.gl/zqbFNuYM2z7u8xux8" class="social-link" target="_blank" rel="noopener noreferrer" aria-label="Google"><i class="fab fa-google" aria-hidden="true"></i></a>
                     <a href="https://wa.me/447940730537" class="social-link" target="_blank" rel="noopener noreferrer" aria-label="WhatsApp"><i class="fab fa-whatsapp" aria-hidden="true"></i></a>
                 </div>
@@ -477,8 +479,8 @@
                     <h4>"ONLINEFIX"</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div style="margin-top: 1rem; font-size: 1.5rem;">
-                        <a href="https://instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
-                        <a href="https://tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
+                        <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                        <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
                 </div>
                 <div class="footer-column">

--- a/data-recovery.html
+++ b/data-recovery.html
@@ -38,11 +38,11 @@
     <meta property="og:image:alt" content="OnlineFix Data Recovery - Hard Drive SSD USB Phone Recovery Guildford">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://onlinefix.co.uk/data-recovery.html">
-    <meta property="twitter:title" content="Data Recovery Guildford | Hard Drive & SSD | No Data No Fee">
-    <meta property="twitter:description" content="Hard drive, SSD, USB &amp; phone data recovery in Guildford. Confidential service. No data, no fee. By appointment only.">
-    <meta property="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://onlinefix.co.uk/data-recovery.html">
+    <meta name="twitter:title" content="Data Recovery Guildford | Hard Drive & SSD | No Data No Fee">
+    <meta name="twitter:description" content="Hard drive, SSD, USB &amp; phone data recovery in Guildford. Confidential service. No data, no fee. By appointment only.">
+    <meta name="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" sizes="512x512" href="/favicon.png">
@@ -98,7 +98,7 @@
         "isPartOf": {
             "@type": "WebSite",
             "name": "OnlineFix",
-            "url": "https://onlinefix.co.uk"
+            "url": "https://onlinefix.co.uk/"
         },
         "about": {
             "@id": "https://onlinefix.co.uk/#organization"
@@ -883,8 +883,8 @@
                     <h4>"ONLINEFIX"</h4>
                     <p style="font-family: monospace; color: #999;">Expert data recovery &amp; device repair in Guildford. Trusted, confidential, and reliable service by Tomas.</p>
                     <div class="social-links" style="margin-top: 1rem; font-size: 1.5rem;">
-                        <a href="https://instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
-                        <a href="https://tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
+                        <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                        <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
                 </div>
                 <div class="footer-column">

--- a/index.html
+++ b/index.html
@@ -41,13 +41,13 @@
     <meta property="business:contact_data:postal_code" content="GU1 4PD">
     <meta property="business:contact_data:country_name" content="UK">
 
-    <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://onlinefix.co.uk/">
-    <meta property="twitter:title" content="OnlineFix - Expert Electronics Repair in Guildford">
-    <meta property="twitter:description" content="Broken device? Get professional same-day repairs for phones, laptops, and consoles in Guildford. Rated 5 Stars.">
-    <meta property="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-twitter-image.jpg">
-    <meta property="twitter:image:alt" content="OnlineFix Electronics Repair Guildford">
+    <!-- Twitter / X Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://onlinefix.co.uk/">
+    <meta name="twitter:title" content="OnlineFix - Expert Electronics Repair in Guildford">
+    <meta name="twitter:description" content="Broken device? Get professional same-day repairs for phones, laptops, and consoles in Guildford. Rated 5 Stars.">
+    <meta name="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-twitter-image.jpg">
+    <meta name="twitter:image:alt" content="OnlineFix Electronics Repair Guildford">
     
     <!-- Favicon -->
     <link rel="icon" type="image/png" sizes="512x512" href="/favicon.png">
@@ -74,7 +74,7 @@
         "name": "OnlineFix",
         "alternateName": "OnlineFix Electronics Repair",
         "description": "Expert electronics repair services in Guildford, Surrey. Specializing in same-day iPhone screen repairs, MacBook logic board fixes, PlayStation HDMI port replacements, and data recovery.",
-        "url": "https://onlinefix.co.uk",
+        "url": "https://onlinefix.co.uk/",
         "telephone": "+447940730537",
         "email": "hello@onlinefix.uk",
         "priceRange": "££",
@@ -136,8 +136,8 @@
             "worstRating": "1"
         },
         "sameAs": [
-            "https://instagram.com/onlinefixrepairs",
-            "https://tiktok.com/@onlinefix",
+            "https://www.instagram.com/onlinefixrepairs",
+            "https://www.tiktok.com/@onlinefix",
             "https://g.page/r/Cc0Vz3kdmt8bEBE/review"
         ],
         "knowsAbout": ["iPhone Repair", "MacBook Repair", "PlayStation Repair", "Xbox Repair", "Data Recovery", "Soldering"]
@@ -1421,8 +1421,8 @@
                     <h4>"ONLINEFIX"</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div class="social-links" style="margin-top: 1rem; font-size: 1.5rem;">
-                        <a href="https://instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
-                        <a href="https://tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
+                        <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                        <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
                 </div>
                 <div class="footer-column">

--- a/iphone-repair.html
+++ b/iphone-repair.html
@@ -38,11 +38,11 @@
     <meta property="og:image:alt" content="OnlineFix iPhone Repair - Screen Battery Charging Port Repair Guildford">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://onlinefix.co.uk/iphone-repair.html">
-    <meta property="twitter:title" content="iPhone Repair Guildford | Same-Day Fix | No Fix No Fee">
-    <meta property="twitter:description" content="iPhone screen, battery &amp; charging port repair in Guildford. Same-day service. 90-day warranty. Appointment only.">
-    <meta property="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://onlinefix.co.uk/iphone-repair.html">
+    <meta name="twitter:title" content="iPhone Repair Guildford | Same-Day Fix | No Fix No Fee">
+    <meta name="twitter:description" content="iPhone screen, battery &amp; charging port repair in Guildford. Same-day service. 90-day warranty. Appointment only.">
+    <meta name="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" sizes="512x512" href="/favicon.png">
@@ -98,7 +98,7 @@
         "isPartOf": {
             "@type": "WebSite",
             "name": "OnlineFix",
-            "url": "https://onlinefix.co.uk"
+            "url": "https://onlinefix.co.uk/"
         },
         "about": {
             "@id": "https://onlinefix.co.uk/#organization"
@@ -883,8 +883,8 @@
                     <h4>"ONLINEFIX"</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics &amp; iPhone repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div class="social-links" style="margin-top: 1rem; font-size: 1.5rem;">
-                        <a href="https://instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
-                        <a href="https://tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
+                        <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                        <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
                 </div>
                 <div class="footer-column">

--- a/macbook-repair.html
+++ b/macbook-repair.html
@@ -38,11 +38,11 @@
     <meta property="og:image:alt" content="OnlineFix MacBook Repair - Logic Board Screen Battery Repair Guildford">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://onlinefix.co.uk/macbook-repair.html">
-    <meta property="twitter:title" content="MacBook Repair Guildford | Same-Day Fix | No Fix No Fee">
-    <meta property="twitter:description" content="MacBook Pro & Air repair in Guildford. Logic board, screen, battery, keyboard & SSD. Same-day service. 90-day warranty. Appointment only.">
-    <meta property="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://onlinefix.co.uk/macbook-repair.html">
+    <meta name="twitter:title" content="MacBook Repair Guildford | Same-Day Fix | No Fix No Fee">
+    <meta name="twitter:description" content="MacBook Pro & Air repair in Guildford. Logic board, screen, battery, keyboard & SSD. Same-day service. 90-day warranty. Appointment only.">
+    <meta name="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" sizes="512x512" href="/favicon.png">
@@ -98,7 +98,7 @@
         "isPartOf": {
             "@type": "WebSite",
             "name": "OnlineFix",
-            "url": "https://onlinefix.co.uk"
+            "url": "https://onlinefix.co.uk/"
         },
         "about": {
             "@id": "https://onlinefix.co.uk/#organization"
@@ -885,8 +885,8 @@
                     <h4>"ONLINEFIX"</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics &amp; MacBook repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div class="social-links" style="margin-top: 1rem; font-size: 1.5rem;">
-                        <a href="https://instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
-                        <a href="https://tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
+                        <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                        <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
                 </div>
                 <div class="footer-column">

--- a/pc-repair.html
+++ b/pc-repair.html
@@ -38,11 +38,11 @@
     <meta property="og:image:alt" content="OnlineFix PC & Desktop Repair - Hardware Software Upgrades Guildford">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://onlinefix.co.uk/pc-repair.html">
-    <meta property="twitter:title" content="PC & Desktop Repair Guildford | Same-Day Fix | No Fix No Fee">
-    <meta property="twitter:description" content="PC &amp; desktop hardware repair, virus removal, SSD &amp; RAM upgrades in Guildford. Same-day service. 90-day warranty. By appointment only.">
-    <meta property="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://onlinefix.co.uk/pc-repair.html">
+    <meta name="twitter:title" content="PC & Desktop Repair Guildford | Same-Day Fix | No Fix No Fee">
+    <meta name="twitter:description" content="PC &amp; desktop hardware repair, virus removal, SSD &amp; RAM upgrades in Guildford. Same-day service. 90-day warranty. By appointment only.">
+    <meta name="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" sizes="512x512" href="/favicon.png">
@@ -98,7 +98,7 @@
         "isPartOf": {
             "@type": "WebSite",
             "name": "OnlineFix",
-            "url": "https://onlinefix.co.uk"
+            "url": "https://onlinefix.co.uk/"
         },
         "about": {
             "@id": "https://onlinefix.co.uk/#organization"
@@ -883,8 +883,8 @@
                     <h4>"ONLINEFIX"</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics &amp; PC repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div class="social-links" style="margin-top: 1rem; font-size: 1.5rem;">
-                        <a href="https://instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
-                        <a href="https://tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
+                        <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                        <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
                 </div>
                 <div class="footer-column">

--- a/reviews.html
+++ b/reviews.html
@@ -14,10 +14,12 @@
     <meta name="description" content="Read genuine customer reviews for OnlineFix electronics repair in Guildford, Surrey. 5-star rated service for smartphone, laptop, tablet, and gaming console repairs. See what our customers say!">
     <meta name="keywords" content="OnlineFix reviews, electronics repair reviews Guildford, smartphone repair testimonials, laptop repair reviews Surrey, customer feedback electronics repair">
     <meta name="author" content="OnlineFix - Tomas">
-    <meta name="robots" content="index, follow">
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <link rel="canonical" href="https://onlinefix.co.uk/reviews.html">
+    <link rel="sitemap" type="application/xml" href="/sitemap.xml">
 
     <meta property="og:type" content="website">
+    <meta property="og:site_name" content="OnlineFix Guildford">
     <meta property="og:url" content="https://onlinefix.co.uk/reviews.html">
     <meta property="og:title" content="Customer Reviews - OnlineFix Electronics Repair Guildford">
     <meta property="og:description" content="Read genuine 5-star customer reviews for professional electronics repair in Guildford, Surrey.">
@@ -68,7 +70,7 @@
         "@type": "LocalBusiness",
         "@id": "https://onlinefix.co.uk/#organization",
         "name": "OnlineFix",
-        "url": "https://onlinefix.co.uk",
+        "url": "https://onlinefix.co.uk/",
         "telephone": "+447940730537",
         "email": "hello@onlinefix.uk",
         "priceRange": "££",
@@ -570,8 +572,8 @@
                     <h4>"ONLINEFIX"</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div style="margin-top: 1rem; font-size: 1.5rem;">
-                        <a href="https://instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
-                        <a href="https://tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
+                        <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                        <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
                 </div>
                 <div class="footer-column">

--- a/services.html
+++ b/services.html
@@ -16,11 +16,13 @@
     <meta name="description" content="Complete electronics repair services in Guildford, Surrey. Smartphone, laptop, tablet, gaming console, desktop PC repairs & data recovery. Expert service by Tomas. Call 07940 730537">
     <meta name="keywords" content="smartphone repair Guildford, laptop repair Surrey, tablet repair, gaming console repair, desktop PC repair, data recovery Guildford, iPhone repair, Samsung repair, MacBook repair">
     <meta name="author" content="OnlineFix - Tomas">
-    <meta name="robots" content="index, follow">
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <link rel="canonical" href="https://onlinefix.co.uk/services.html">
+    <link rel="sitemap" type="application/xml" href="/sitemap.xml">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
+    <meta property="og:site_name" content="OnlineFix Guildford">
     <meta property="og:url" content="https://onlinefix.co.uk/services.html">
     <meta property="og:title" content="Electronics Repair Services in Guildford | OnlineFix">
     <meta property="og:description" content="Professional electronics repair services in Guildford. Smartphones, laptops, tablets, gaming consoles, desktop PCs, and data recovery.">
@@ -80,7 +82,7 @@
         "isPartOf": {
             "@type": "WebSite",
             "name": "OnlineFix",
-            "url": "https://onlinefix.co.uk"
+            "url": "https://onlinefix.co.uk/"
         },
         "about": {
             "@id": "https://onlinefix.co.uk/#organization"
@@ -789,8 +791,8 @@
                     <h4>"ONLINEFIX"</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div style="margin-top: 1rem; font-size: 1.5rem;">
-                        <a href="https://instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
-                        <a href="https://tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
+                        <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                        <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
                 </div>
                 <div class="footer-column">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,7 +4,7 @@
   <!-- Homepage - Highest priority, updated weekly -->
   <url>
     <loc>https://onlinefix.co.uk/</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -12,7 +12,7 @@
   <!-- Services page - High priority, updated monthly -->
   <url>
     <loc>https://onlinefix.co.uk/services.html</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -20,7 +20,7 @@
   <!-- Console Repair landing page - High priority, service-specific SEO page -->
   <url>
     <loc>https://onlinefix.co.uk/console-repair.html</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -28,7 +28,7 @@
   <!-- iPhone Repair landing page - High priority, service-specific SEO page -->
   <url>
     <loc>https://onlinefix.co.uk/iphone-repair.html</loc>
-    <lastmod>2026-02-08</lastmod>
+    <lastmod>2026-02-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -36,7 +36,7 @@
   <!-- MacBook Repair landing page - High priority, service-specific SEO page -->
   <url>
     <loc>https://onlinefix.co.uk/macbook-repair.html</loc>
-    <lastmod>2026-02-07</lastmod>
+    <lastmod>2026-02-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -44,7 +44,7 @@
   <!-- Tablet Repair landing page - High priority, service-specific SEO page -->
   <url>
     <loc>https://onlinefix.co.uk/tablet-repair.html</loc>
-    <lastmod>2026-02-14</lastmod>
+    <lastmod>2026-02-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -52,7 +52,7 @@
   <!-- PC Repair landing page - High priority, service-specific SEO page -->
   <url>
     <loc>https://onlinefix.co.uk/pc-repair.html</loc>
-    <lastmod>2026-02-14</lastmod>
+    <lastmod>2026-02-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -60,7 +60,7 @@
   <!-- Data Recovery landing page - High priority, service-specific SEO page -->
   <url>
     <loc>https://onlinefix.co.uk/data-recovery.html</loc>
-    <lastmod>2026-02-14</lastmod>
+    <lastmod>2026-02-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -68,7 +68,7 @@
   <!-- Contact page - High priority, rarely changes -->
   <url>
     <loc>https://onlinefix.co.uk/contact.html</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -76,7 +76,7 @@
   <!-- Reviews page - Medium priority, updated monthly -->
   <url>
     <loc>https://onlinefix.co.uk/reviews.html</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -84,7 +84,7 @@
   <!-- About page - Lower priority, rarely changes -->
   <url>
     <loc>https://onlinefix.co.uk/about.html</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/tablet-repair.html
+++ b/tablet-repair.html
@@ -38,11 +38,11 @@
     <meta property="og:image:alt" content="OnlineFix iPad & Tablet Repair - Screen Battery Charging Port Repair Guildford">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://onlinefix.co.uk/tablet-repair.html">
-    <meta property="twitter:title" content="iPad & Tablet Repair Guildford | Same-Day Fix | No Fix No Fee">
-    <meta property="twitter:description" content="iPad &amp; tablet screen, battery &amp; charging port repair in Guildford. Same-day service. 90-day warranty. Appointment only.">
-    <meta property="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://onlinefix.co.uk/tablet-repair.html">
+    <meta name="twitter:title" content="iPad & Tablet Repair Guildford | Same-Day Fix | No Fix No Fee">
+    <meta name="twitter:description" content="iPad &amp; tablet screen, battery &amp; charging port repair in Guildford. Same-day service. 90-day warranty. Appointment only.">
+    <meta name="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.jpg">
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" sizes="512x512" href="/favicon.png">
@@ -98,7 +98,7 @@
         "isPartOf": {
             "@type": "WebSite",
             "name": "OnlineFix",
-            "url": "https://onlinefix.co.uk"
+            "url": "https://onlinefix.co.uk/"
         },
         "about": {
             "@id": "https://onlinefix.co.uk/#organization"
@@ -883,8 +883,8 @@
                     <h4>"ONLINEFIX"</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics &amp; tablet repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div class="social-links" style="margin-top: 1rem; font-size: 1.5rem;">
-                        <a href="https://instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
-                        <a href="https://tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
+                        <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                        <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
                 </div>
                 <div class="footer-column">


### PR DESCRIPTION
- Add trailing slash to all schema.org `url` fields pointing to root domain (https://onlinefix.co.uk -> https://onlinefix.co.uk/) 