### PR TITLE
Remove mobile sticky "Call Us" button from all pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -98,10 +98,6 @@
         @media (hover: hover) { .error-btn:hover { transform: translate(4px, 4px); box-shadow: -4px -4px 0 var(--hex-black); } }
         .error-hint { font-family: monospace; color: #999; font-size: 0.75rem; text-transform: uppercase; margin-top: 1.5rem; }
 
-        /* MOBILE STICKY */
-        .mobile-sticky-bar { display: none; position: fixed; bottom: 0; left: 0; width: 100%; background: rgba(255,255,255,0.85); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border: none; box-shadow: 0 -5px 15px rgba(0,0,0,0.05); padding: 12px; padding-bottom: max(12px, var(--safe-area-bottom)); z-index: 9999; }
-        .sticky-call-btn { display: block; background: var(--gradient-blue); color: var(--hex-white); text-align: center; padding: 16px; text-decoration: none; font-weight: 900; text-transform: uppercase; border: none; border-radius: 4px; font-size: 1.1rem; box-shadow: 0 4px 15px rgba(0,51,255,0.3); }
-        .sticky-call-btn:active { transform: scale(0.98); }
 
         @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } }
 
@@ -114,7 +110,6 @@
             .nav-menu.active { display: flex; }
             .nav-link { padding: 1.5rem; border-left: none; border-bottom: 1px solid #eee; min-height: 48px; }
             .nav-cta { padding: 1.5rem; justify-content: center; border-left: none; min-height: 48px; }
-            .mobile-sticky-bar { display: block; }
             .error-box { padding: 2rem 1.5rem; box-shadow: 6px 6px 0 var(--hex-black); margin: 0 1rem; }
             .error-code { letter-spacing: -2px; }
         }
@@ -144,9 +139,6 @@
         </div>
     </nav>
 
-    <div class="mobile-sticky-bar" role="complementary" aria-label="Quick contact">
-        <a href="tel:+447940730537" class="sticky-call-btn">"CALL US"</a>
-    </div>
 
     <main id="main">
         <section class="error-section" aria-label="Page not found">

--- a/about.html
+++ b/about.html
@@ -776,42 +776,6 @@
             padding-top: 2rem;
         }
 
-        /* MOBILE STICKY */
-        .mobile-sticky-bar {
-            display: none;
-            position: fixed;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            background: rgba(255, 255, 255, 0.85);
-            backdrop-filter: blur(10px);
-            -webkit-backdrop-filter: blur(10px);
-            border: none;
-            box-shadow: 0 -5px 15px rgba(0, 0, 0, 0.05);
-            padding: 12px;
-            padding-bottom: max(12px, var(--safe-area-bottom));
-            z-index: 9999;
-        }
-
-        .sticky-call-btn {
-            display: block;
-            background: var(--gradient-blue);
-            color: var(--hex-white);
-            text-align: center;
-            padding: 16px;
-            text-decoration: none;
-            font-weight: 900;
-            text-transform: uppercase;
-            border: none;
-            border-radius: 4px;
-            font-size: 1.1rem;
-            box-shadow: 0 4px 15px rgba(0, 51, 255, 0.3);
-        }
-
-        .sticky-call-btn:active {
-            transform: scale(0.98);
-        }
-
         .scroll-hint {
             display: none;
             text-align: right;
@@ -910,10 +874,6 @@
                 justify-content: center;
                 border-left: none;
                 min-height: 48px;
-            }
-
-            .mobile-sticky-bar {
-                display: block;
             }
 
             .page-header-box {
@@ -1094,9 +1054,6 @@
         </div>
     </nav>
 
-    <div class="mobile-sticky-bar" role="complementary" aria-label="Quick contact">
-        <a href="tel:+447940730537" class="sticky-call-btn">"CALL US"</a>
-    </div>
 
     <main id="main">
         <section class="page-header" aria-label="Page header">

--- a/console-repair.html
+++ b/console-repair.html
@@ -1092,42 +1092,6 @@
             padding-top: 2rem;
         }
 
-        /* MOBILE STICKY */
-        .mobile-sticky-bar {
-            display: none;
-            position: fixed;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            background: rgba(255, 255, 255, 0.85);
-            backdrop-filter: blur(10px);
-            -webkit-backdrop-filter: blur(10px);
-            border: none;
-            box-shadow: 0 -5px 15px rgba(0, 0, 0, 0.05);
-            padding: 12px;
-            padding-bottom: max(12px, var(--safe-area-bottom));
-            z-index: 9999;
-        }
-
-        .sticky-call-btn {
-            display: block;
-            background: var(--gradient-blue);
-            color: var(--hex-white);
-            text-align: center;
-            padding: 16px;
-            text-decoration: none;
-            font-weight: 900;
-            text-transform: uppercase;
-            border: none;
-            border-radius: 4px;
-            font-size: 1.1rem;
-            box-shadow: 0 4px 15px rgba(0, 51, 255, 0.3);
-        }
-
-        .sticky-call-btn:active {
-            transform: scale(0.98);
-        }
-
         /* SCROLL HINT */
         .scroll-hint {
             display: none;
@@ -1228,10 +1192,6 @@
                 justify-content: center;
                 border-left: none;
                 min-height: 48px;
-            }
-
-            .mobile-sticky-bar {
-                display: block;
             }
 
             /* PAGE HEADER — prevent overflow */
@@ -2093,10 +2053,6 @@
         </div>
     </footer>
 
-    <!-- Mobile Sticky Bar -->
-    <div class="mobile-sticky-bar" role="complementary" aria-label="Quick contact">
-        <a href="tel:+447940730537" class="sticky-call-btn">"CALL US"</a>
-    </div>
 
     <!-- Font Awesome -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js"

--- a/contact.html
+++ b/contact.html
@@ -821,42 +821,6 @@
             padding-top: 2rem;
         }
 
-        /* MOBILE STICKY */
-        .mobile-sticky-bar {
-            display: none;
-            position: fixed;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            background: rgba(255, 255, 255, 0.85);
-            backdrop-filter: blur(10px);
-            -webkit-backdrop-filter: blur(10px);
-            border: none;
-            box-shadow: 0 -5px 15px rgba(0, 0, 0, 0.05);
-            padding: 12px;
-            padding-bottom: max(12px, var(--safe-area-bottom));
-            z-index: 9999;
-        }
-
-        .sticky-call-btn {
-            display: block;
-            background: var(--gradient-blue);
-            color: var(--hex-white);
-            text-align: center;
-            padding: 16px;
-            text-decoration: none;
-            font-weight: 900;
-            text-transform: uppercase;
-            border: none;
-            border-radius: 4px;
-            font-size: 1.1rem;
-            box-shadow: 0 4px 15px rgba(0, 51, 255, 0.3);
-        }
-
-        .sticky-call-btn:active {
-            transform: scale(0.98);
-        }
-
         @media (prefers-reduced-motion: reduce) {
 
             *,
@@ -919,10 +883,6 @@
                 padding: 1.5rem;
                 justify-content: center;
                 border-left: none;
-            }
-
-            .mobile-sticky-bar {
-                display: block;
             }
 
             .nav-link {
@@ -1092,9 +1052,6 @@
         </div>
     </nav>
 
-    <div class="mobile-sticky-bar" role="complementary" aria-label="Quick contact">
-        <a href="tel:+447940730537" class="sticky-call-btn">"CALL US"</a>
-    </div>
 
     <main id="main">
         <section class="page-header" aria-label="Page header">

--- a/data-recovery.html
+++ b/data-recovery.html
@@ -387,10 +387,6 @@
         .footer-links a:hover { color: var(--hex-white); text-decoration: underline; }
         .copyright { text-align: left; font-family: monospace; color: #555; font-size: 0.7rem; border-top: 1px solid #333; padding-top: 2rem; }
 
-        /* MOBILE STICKY */
-        .mobile-sticky-bar { display: none; position: fixed; bottom: 0; left: 0; width: 100%; background: rgba(255,255,255,0.85); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border: none; box-shadow: 0 -5px 15px rgba(0,0,0,0.05); padding: 12px; padding-bottom: max(12px, var(--safe-area-bottom)); z-index: 9999; }
-        .sticky-call-btn { display: block; background: var(--gradient-blue); color: var(--hex-white); text-align: center; padding: 16px; text-decoration: none; font-weight: 900; text-transform: uppercase; border: none; border-radius: 4px; font-size: 1.1rem; box-shadow: 0 4px 15px rgba(0,51,255,0.3); }
-        .sticky-call-btn:active { transform: scale(0.98); }
 
         /* SCROLL HINT */
         .scroll-hint { display: none; text-align: right; font-size: 0.7rem; color: var(--hex-accent); margin-bottom: 0.5rem; font-family: monospace; text-transform: uppercase; font-weight: 700; animation: pulse-hint 2s infinite; }
@@ -410,8 +406,6 @@
             .nav-menu.active { display: flex; }
             .nav-link { padding: 1.5rem; border-left: none; border-bottom: 1px solid #eee; min-height: 48px; }
             .nav-cta { padding: 1.5rem; justify-content: center; border-left: none; min-height: 48px; }
-            .mobile-sticky-bar { display: block; }
-
             /* PAGE HEADER */
             .page-header-box { padding: 1.5rem 1rem; box-shadow: 6px 6px 0 var(--hex-black); }
             .page-title { font-size: clamp(1.8rem, 7vw, 2.5rem); letter-spacing: -1px; }
@@ -919,10 +913,6 @@
         </div>
     </footer>
 
-    <!-- Mobile Sticky Bar -->
-    <div class="mobile-sticky-bar" role="complementary" aria-label="Quick contact">
-        <a href="tel:+447940730537" class="sticky-call-btn">"CALL US"</a>
-    </div>
 
     <!-- Font Awesome -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js" integrity="sha512-fD9DI5bZwQxOi7MhYWnnNPlvXdp/2Pj3XSTRrFs5FQa4mizyGLnJcN6tuvUS6LbmgN1ut+XGSABKvjN0H6Aoow==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>

--- a/index.html
+++ b/index.html
@@ -1009,40 +1009,6 @@
 
         /* MOBILE OPTIMIZATIONS & FIXES */
 
-        .mobile-sticky-bar {
-            display: none;
-            position: fixed;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            background: rgba(255, 255, 255, 0.85);
-            backdrop-filter: blur(10px);
-            -webkit-backdrop-filter: blur(10px);
-            border: none;
-            box-shadow: 0 -5px 15px rgba(0, 0, 0, 0.05);
-            padding: 12px;
-            padding-bottom: max(12px, var(--safe-area-bottom));
-            z-index: 9999;
-        }
-
-        .sticky-call-btn {
-            display: block;
-            background: var(--gradient-blue);
-            color: var(--hex-white);
-            text-align: center;
-            padding: 16px;
-            text-decoration: none;
-            font-weight: 900;
-            text-transform: uppercase;
-            border: none;
-            border-radius: 4px;
-            font-size: 1.1rem;
-            box-shadow: 0 4px 15px rgba(0, 51, 255, 0.3);
-        }
-
-        .sticky-call-btn:active {
-            transform: scale(0.98);
-        }
 
         /* Reduced Motion Support */
         @media (prefers-reduced-motion: reduce) {
@@ -1118,10 +1084,6 @@
                 justify-content: center;
                 border-left: none;
                 min-height: 48px;
-            }
-
-            .mobile-sticky-bar {
-                display: block;
             }
 
             .hero {
@@ -1300,12 +1262,6 @@
         </div>
     </nav>
 
-    <!-- Mobile Sticky Footer -->
-    <div class="mobile-sticky-bar" role="complementary" aria-label="Quick contact">
-        <a href="tel:+447940730537" class="sticky-call-btn">
-            "CALL US"
-        </a>
-    </div>
 
     <main id="main">
         <!-- Hero Section -->

--- a/iphone-repair.html
+++ b/iphone-repair.html
@@ -387,10 +387,6 @@
         .footer-links a:hover { color: var(--hex-white); text-decoration: underline; }
         .copyright { text-align: left; font-family: monospace; color: #555; font-size: 0.7rem; border-top: 1px solid #333; padding-top: 2rem; }
 
-        /* MOBILE STICKY */
-        .mobile-sticky-bar { display: none; position: fixed; bottom: 0; left: 0; width: 100%; background: rgba(255,255,255,0.85); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border: none; box-shadow: 0 -5px 15px rgba(0,0,0,0.05); padding: 12px; padding-bottom: max(12px, var(--safe-area-bottom)); z-index: 9999; }
-        .sticky-call-btn { display: block; background: var(--gradient-blue); color: var(--hex-white); text-align: center; padding: 16px; text-decoration: none; font-weight: 900; text-transform: uppercase; border: none; border-radius: 4px; font-size: 1.1rem; box-shadow: 0 4px 15px rgba(0,51,255,0.3); }
-        .sticky-call-btn:active { transform: scale(0.98); }
 
         /* SCROLL HINT */
         .scroll-hint { display: none; text-align: right; font-size: 0.7rem; color: var(--hex-accent); margin-bottom: 0.5rem; font-family: monospace; text-transform: uppercase; font-weight: 700; animation: pulse-hint 2s infinite; }
@@ -410,8 +406,6 @@
             .nav-menu.active { display: flex; }
             .nav-link { padding: 1.5rem; border-left: none; border-bottom: 1px solid #eee; min-height: 48px; }
             .nav-cta { padding: 1.5rem; justify-content: center; border-left: none; min-height: 48px; }
-            .mobile-sticky-bar { display: block; }
-
             /* PAGE HEADER */
             .page-header-box { padding: 1.5rem 1rem; box-shadow: 6px 6px 0 var(--hex-black); }
             .page-title { font-size: clamp(1.8rem, 7vw, 2.5rem); letter-spacing: -1px; }
@@ -919,10 +913,6 @@
         </div>
     </footer>
 
-    <!-- Mobile Sticky Bar -->
-    <div class="mobile-sticky-bar" role="complementary" aria-label="Quick contact">
-        <a href="tel:+447940730537" class="sticky-call-btn">"CALL US"</a>
-    </div>
 
     <!-- Font Awesome -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js" integrity="sha512-fD9DI5bZwQxOi7MhYWnnNPlvXdp/2Pj3XSTRrFs5FQa4mizyGLnJcN6tuvUS6LbmgN1ut+XGSABKvjN0H6Aoow==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>

--- a/macbook-repair.html
+++ b/macbook-repair.html
@@ -387,10 +387,6 @@
         .footer-links a:hover { color: var(--hex-white); text-decoration: underline; }
         .copyright { text-align: left; font-family: monospace; color: #555; font-size: 0.7rem; border-top: 1px solid #333; padding-top: 2rem; }
 
-        /* MOBILE STICKY */
-        .mobile-sticky-bar { display: none; position: fixed; bottom: 0; left: 0; width: 100%; background: rgba(255,255,255,0.85); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border: none; box-shadow: 0 -5px 15px rgba(0,0,0,0.05); padding: 12px; padding-bottom: max(12px, var(--safe-area-bottom)); z-index: 9999; }
-        .sticky-call-btn { display: block; background: var(--gradient-blue); color: var(--hex-white); text-align: center; padding: 16px; text-decoration: none; font-weight: 900; text-transform: uppercase; border: none; border-radius: 4px; font-size: 1.1rem; box-shadow: 0 4px 15px rgba(0,51,255,0.3); }
-        .sticky-call-btn:active { transform: scale(0.98); }
 
         /* SCROLL HINT */
         .scroll-hint { display: none; text-align: right; font-size: 0.7rem; color: var(--hex-accent); margin-bottom: 0.5rem; font-family: monospace; text-transform: uppercase; font-weight: 700; animation: pulse-hint 2s infinite; }
@@ -410,8 +406,6 @@
             .nav-menu.active { display: flex; }
             .nav-link { padding: 1.5rem; border-left: none; border-bottom: 1px solid #eee; min-height: 48px; }
             .nav-cta { padding: 1.5rem; justify-content: center; border-left: none; min-height: 48px; }
-            .mobile-sticky-bar { display: block; }
-
             /* PAGE HEADER */
             .page-header-box { padding: 1.5rem 1rem; box-shadow: 6px 6px 0 var(--hex-black); }
             .page-title { font-size: clamp(1.8rem, 7vw, 2.5rem); letter-spacing: -1px; }
@@ -921,10 +915,6 @@
         </div>
     </footer>
 
-    <!-- Mobile Sticky Bar -->
-    <div class="mobile-sticky-bar" role="complementary" aria-label="Quick contact">
-        <a href="tel:+447940730537" class="sticky-call-btn">"CALL US"</a>
-    </div>
 
     <!-- Font Awesome -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js" integrity="sha512-fD9DI5bZwQxOi7MhYWnnNPlvXdp/2Pj3XSTRrFs5FQa4mizyGLnJcN6tuvUS6LbmgN1ut+XGSABKvjN0H6Aoow==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>

--- a/pc-repair.html
+++ b/pc-repair.html
@@ -1107,42 +1107,6 @@
             padding-top: 2rem;
         }
 
-        /* MOBILE STICKY */
-        .mobile-sticky-bar {
-            display: none;
-            position: fixed;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            background: rgba(255, 255, 255, 0.85);
-            backdrop-filter: blur(10px);
-            -webkit-backdrop-filter: blur(10px);
-            border: none;
-            box-shadow: 0 -5px 15px rgba(0, 0, 0, 0.05);
-            padding: 12px;
-            padding-bottom: max(12px, var(--safe-area-bottom));
-            z-index: 9999;
-        }
-
-        .sticky-call-btn {
-            display: block;
-            background: var(--gradient-blue);
-            color: var(--hex-white);
-            text-align: center;
-            padding: 16px;
-            text-decoration: none;
-            font-weight: 900;
-            text-transform: uppercase;
-            border: none;
-            border-radius: 4px;
-            font-size: 1.1rem;
-            box-shadow: 0 4px 15px rgba(0, 51, 255, 0.3);
-        }
-
-        .sticky-call-btn:active {
-            transform: scale(0.98);
-        }
-
         /* SCROLL HINT */
         .scroll-hint {
             display: none;
@@ -1243,10 +1207,6 @@
                 justify-content: center;
                 border-left: none;
                 min-height: 48px;
-            }
-
-            .mobile-sticky-bar {
-                display: block;
             }
 
             /* PAGE HEADER */
@@ -2129,10 +2089,6 @@
         </div>
     </footer>
 
-    <!-- Mobile Sticky Bar -->
-    <div class="mobile-sticky-bar" role="complementary" aria-label="Quick contact">
-        <a href="tel:+447940730537" class="sticky-call-btn">"CALL US"</a>
-    </div>
 
     <!-- Font Awesome -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js"

--- a/reviews.html
+++ b/reviews.html
@@ -856,42 +856,6 @@
             padding-top: 2rem;
         }
 
-        /* MOBILE STICKY */
-        .mobile-sticky-bar {
-            display: none;
-            position: fixed;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            background: rgba(255, 255, 255, 0.85);
-            backdrop-filter: blur(10px);
-            -webkit-backdrop-filter: blur(10px);
-            border: none;
-            box-shadow: 0 -5px 15px rgba(0, 0, 0, 0.05);
-            padding: 12px;
-            padding-bottom: max(12px, var(--safe-area-bottom));
-            z-index: 9999;
-        }
-
-        .sticky-call-btn {
-            display: block;
-            background: var(--gradient-blue);
-            color: var(--hex-white);
-            text-align: center;
-            padding: 16px;
-            text-decoration: none;
-            font-weight: 900;
-            text-transform: uppercase;
-            border: none;
-            border-radius: 4px;
-            font-size: 1.1rem;
-            box-shadow: 0 4px 15px rgba(0, 51, 255, 0.3);
-        }
-
-        .sticky-call-btn:active {
-            transform: scale(0.98);
-        }
-
         .scroll-hint {
             display: none;
             text-align: right;
@@ -990,10 +954,6 @@
                 justify-content: center;
                 border-left: none;
                 min-height: 48px;
-            }
-
-            .mobile-sticky-bar {
-                display: block;
             }
 
             .page-header-box {
@@ -1154,9 +1114,6 @@
         </div>
     </nav>
 
-    <div class="mobile-sticky-bar" role="complementary" aria-label="Quick contact">
-        <a href="tel:+447940730537" class="sticky-call-btn">"CALL US"</a>
-    </div>
 
     <main id="main">
         <section class="page-header" aria-label="Page header">

--- a/services.html
+++ b/services.html
@@ -765,42 +765,6 @@
             padding-top: 2rem;
         }
 
-        /* MOBILE STICKY BAR */
-        .mobile-sticky-bar {
-            display: none;
-            position: fixed;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            background: rgba(255, 255, 255, 0.85);
-            backdrop-filter: blur(10px);
-            -webkit-backdrop-filter: blur(10px);
-            border: none;
-            box-shadow: 0 -5px 15px rgba(0, 0, 0, 0.05);
-            padding: 12px;
-            padding-bottom: max(12px, var(--safe-area-bottom));
-            z-index: 9999;
-        }
-
-        .sticky-call-btn {
-            display: block;
-            background: var(--gradient-blue);
-            color: var(--hex-white);
-            text-align: center;
-            padding: 16px;
-            text-decoration: none;
-            font-weight: 900;
-            text-transform: uppercase;
-            border: none;
-            border-radius: 4px;
-            font-size: 1.1rem;
-            box-shadow: 0 4px 15px rgba(0, 51, 255, 0.3);
-        }
-
-        .sticky-call-btn:active {
-            transform: scale(0.98);
-        }
-
         @media (prefers-reduced-motion: reduce) {
 
             *,
@@ -869,10 +833,6 @@
                 justify-content: center;
                 border-left: none;
                 min-height: 48px;
-            }
-
-            .mobile-sticky-bar {
-                display: block;
             }
 
             .page-header-box {
@@ -1007,10 +967,6 @@
         </div>
     </nav>
 
-    <!-- Mobile Sticky Footer -->
-    <div class="mobile-sticky-bar" role="complementary" aria-label="Quick contact">
-        <a href="tel:+447940730537" class="sticky-call-btn">"CALL US"</a>
-    </div>
 
     <main id="main">
         <!-- Page Header -->

--- a/tablet-repair.html
+++ b/tablet-repair.html
@@ -387,10 +387,6 @@
         .footer-links a:hover { color: var(--hex-white); text-decoration: underline; }
         .copyright { text-align: left; font-family: monospace; color: #555; font-size: 0.7rem; border-top: 1px solid #333; padding-top: 2rem; }
 
-        /* MOBILE STICKY */
-        .mobile-sticky-bar { display: none; position: fixed; bottom: 0; left: 0; width: 100%; background: rgba(255,255,255,0.85); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border: none; box-shadow: 0 -5px 15px rgba(0,0,0,0.05); padding: 12px; padding-bottom: max(12px, var(--safe-area-bottom)); z-index: 9999; }
-        .sticky-call-btn { display: block; background: var(--gradient-blue); color: var(--hex-white); text-align: center; padding: 16px; text-decoration: none; font-weight: 900; text-transform: uppercase; border: none; border-radius: 4px; font-size: 1.1rem; box-shadow: 0 4px 15px rgba(0,51,255,0.3); }
-        .sticky-call-btn:active { transform: scale(0.98); }
 
         /* SCROLL HINT */
         .scroll-hint { display: none; text-align: right; font-size: 0.7rem; color: var(--hex-accent); margin-bottom: 0.5rem; font-family: monospace; text-transform: uppercase; font-weight: 700; animation: pulse-hint 2s infinite; }
@@ -410,8 +406,6 @@
             .nav-menu.active { display: flex; }
             .nav-link { padding: 1.5rem; border-left: none; border-bottom: 1px solid #eee; min-height: 48px; }
             .nav-cta { padding: 1.5rem; justify-content: center; border-left: none; min-height: 48px; }
-            .mobile-sticky-bar { display: block; }
-
             /* PAGE HEADER */
             .page-header-box { padding: 1.5rem 1rem; box-shadow: 6px 6px 0 var(--hex-black); }
             .page-title { font-size: clamp(1.8rem, 7vw, 2.5rem); letter-spacing: -1px; }
@@ -919,10 +913,6 @@
         </div>
     </footer>
 
-    <!-- Mobile Sticky Bar -->
-    <div class="mobile-sticky-bar" role="complementary" aria-label="Quick contact">
-        <a href="tel:+447940730537" class="sticky-call-btn">"CALL US"</a>
-    </div>
 
     <!-- Font Awesome -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js" integrity="sha512-fD9DI5bZwQxOi7MhYWnnNPlvXdp/2Pj3XSTRrFs5FQa4mizyGLnJcN6tuvUS6LbmgN1ut+XGSABKvjN0H6Aoow==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>


### PR DESCRIPTION
Removes the fixed-position mobile-sticky-bar and sticky-call-btn from all 12 pages. The floating call bar at the bottom of the screen on mobile is no longer needed.

https://claude.ai/code/session_01RFv7gbu7YdLYcvFXafuJ6s