### PR TITLE
Fix TM symbol size on hero logo - scale down to match expected propor…

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,9 +302,9 @@
 
         .logo::after {
             content: "\2122";
-            font-size: 0.4em;
+            font-size: 0.18em;
             position: relative;
-            top: -0.6em;
+            top: -0.9em;
             margin-left: 2px;
             line-height: 0;
             vertical-align: baseline;


### PR DESCRIPTION
…tion

The hero logo font-size is up to 7rem, so 0.4em made the TM symbol disproportionately large. Reduced to 0.18em with adjusted 