### PR TITLE
Fix TM symbol alignment on hero logo using absolute positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,12 +302,11 @@
 
         .logo::after {
             content: "\2122";
-            font-size: 0.18em;
-            position: relative;
-            top: -0.9em;
-            margin-left: 2px;
-            line-height: 0;
-            vertical-align: baseline;
+            font-size: 0.25em;
+            position: absolute;
+            top: 0;
+            right: -0.8em;
+            line-height: 1;
             color: var(--hex-black);
         }
 


### PR DESCRIPTION
Position the TM at the top-right of the logo using position: absolute instead of relative, so it actually sits at the top of the text regardless of font size. Previous relative positioning only nudged from the baseline which wasn't enough for the large hero text.

