### PR TITLE
Restore dark background on WORKFLOW section

### DIFF
--- a/index.html
+++ b/index.html
@@ -378,7 +378,8 @@
 
         .process-section {
             padding: 4rem 0;
-            background: var(--hex-white);
+            background: var(--hex-black);
+            color: var(--hex-white);
             border-top: 5px solid var(--hex-black);
         }
 
@@ -390,10 +391,10 @@
 
         .process-item {
             font-family: 'Courier New', Courier, monospace;
-            background: #fff;
+            background: transparent;
             padding: 1.5rem;
-            border: 1px dashed var(--hex-black);
-            box-shadow: 5px 5px 0 #ddd;
+            border: 1px dashed #555;
+            box-shadow: 5px 5px 0 #222;
             position: relative;
         }
 
@@ -412,12 +413,12 @@
             font-size: 1.3rem;
             text-transform: uppercase;
             margin-bottom: 1rem;
-            color: var(--hex-black);
+            color: var(--hex-white);
         }
 
         .process-item p {
             font-family: 'Courier New', Courier, monospace;
-            color: var(--hex-black);
+            color: #aaa;
             font-size: 0.9rem;
             line-height: 1.4;
         }


### PR DESCRIPTION
Keep the new card design (dashed border, box-shadow, monospace) but with dark-themed colours: transparent cards, #555 dashed borders, #222 shadow, white headings, #aaa body text.

https://claude.ai/code/session_01FVhhVczoRnT1av6sUzT8mX