### PR TITLE
Remove footer logo image from all pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -689,7 +689,6 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-column">
-                    <img src="/images/onlinefix-logo.webp" alt="OnlineFix - Electronics repair in Guildford, Surrey" width="120" height="120" loading="lazy" style="margin-bottom: 0.5rem;">
                     <h4>ONLINEFIX</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics repair in Guildford. Trusted,
                         fast, and reliable service by Tomas.</p>

--- a/console-repair.html
+++ b/console-repair.html
@@ -1463,7 +1463,6 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-column">
-                    <img src="/images/onlinefix-logo.webp" alt="OnlineFix - Electronics repair in Guildford, Surrey" width="120" height="120" loading="lazy" style="margin-bottom: 0.5rem;">
                     <h4>ONLINEFIX</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics &amp; console repair in
                         Guildford. Trusted, fast, and reliable service by Tomas.</p>

--- a/contact.html
+++ b/contact.html
@@ -777,7 +777,6 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-column">
-                    <img src="/images/onlinefix-logo.webp" alt="OnlineFix - Electronics repair in Guildford, Surrey" width="120" height="120" loading="lazy" style="margin-bottom: 0.5rem;">
                     <h4>ONLINEFIX</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics repair in Guildford. Trusted,
                         fast, and reliable service by Tomas.</p>

--- a/data-recovery.html
+++ b/data-recovery.html
@@ -873,7 +873,6 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-column">
-                    <img src="/images/onlinefix-logo.webp" alt="OnlineFix - Electronics repair in Guildford, Surrey" width="120" height="120" loading="lazy" style="margin-bottom: 0.5rem;">
                     <h4>ONLINEFIX</h4>
                     <p style="font-family: monospace; color: #999;">Expert data recovery &amp; device repair in Guildford. Trusted, confidential, and reliable service by Tomas.</p>
                     <div class="social-links" style="margin-top: 1rem; font-size: 1.5rem;">

--- a/index.html
+++ b/index.html
@@ -882,7 +882,6 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-column">
-                    <img src="/images/onlinefix-logo.webp" alt="OnlineFix - Electronics repair in Guildford, Surrey" width="120" height="120" loading="lazy" style="margin-bottom: 0.5rem;">
                     <h4>ONLINEFIX</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics repair in Guildford. Trusted,
                         fast, and reliable service by Tomas.</p>

--- a/iphone-repair.html
+++ b/iphone-repair.html
@@ -873,7 +873,6 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-column">
-                    <img src="/images/onlinefix-logo.webp" alt="OnlineFix - Electronics repair in Guildford, Surrey" width="120" height="120" loading="lazy" style="margin-bottom: 0.5rem;">
                     <h4>ONLINEFIX</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics &amp; iPhone repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div class="social-links" style="margin-top: 1rem; font-size: 1.5rem;">

--- a/macbook-repair.html
+++ b/macbook-repair.html
@@ -875,7 +875,6 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-column">
-                    <img src="/images/onlinefix-logo.webp" alt="OnlineFix - Electronics repair in Guildford, Surrey" width="120" height="120" loading="lazy" style="margin-bottom: 0.5rem;">
                     <h4>ONLINEFIX</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics &amp; MacBook repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div class="social-links" style="margin-top: 1rem; font-size: 1.5rem;">

--- a/pc-repair.html
+++ b/pc-repair.html
@@ -1506,7 +1506,6 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-column">
-                    <img src="/images/onlinefix-logo.webp" alt="OnlineFix - Electronics repair in Guildford, Surrey" width="120" height="120" loading="lazy" style="margin-bottom: 0.5rem;">
                     <h4>ONLINEFIX</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics &amp; PC repair in Guildford.
                         Trusted, fast, and reliable service by Tomas.</p>

--- a/privacy.html
+++ b/privacy.html
@@ -377,7 +377,6 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-column">
-                    <img src="/images/onlinefix-logo.webp" alt="OnlineFix - Electronics repair in Guildford, Surrey" width="120" height="120" loading="lazy" style="margin-bottom: 0.5rem;">
                     <h4>ONLINEFIX</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics repair in Guildford. Trusted,
                         fast, and reliable service by Tomas.</p>

--- a/reviews.html
+++ b/reviews.html
@@ -861,7 +861,6 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-column">
-                    <img src="/images/onlinefix-logo.webp" alt="OnlineFix - Electronics repair in Guildford, Surrey" width="120" height="120" loading="lazy" style="margin-bottom: 0.5rem;">
                     <h4>ONLINEFIX</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics repair in Guildford. Trusted,
                         fast, and reliable service by Tomas.</p>

--- a/services.html
+++ b/services.html
@@ -699,7 +699,6 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-column">
-                    <img src="/images/onlinefix-logo.webp" alt="OnlineFix - Electronics repair in Guildford, Surrey" width="120" height="120" loading="lazy" style="margin-bottom: 0.5rem;">
                     <h4>ONLINEFIX</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics repair in Guildford. Trusted,
                         fast, and reliable service by Tomas.</p>

--- a/tablet-repair.html
+++ b/tablet-repair.html
@@ -873,7 +873,6 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-column">
-                    <img src="/images/onlinefix-logo.webp" alt="OnlineFix - Electronics repair in Guildford, Surrey" width="120" height="120" loading="lazy" style="margin-bottom: 0.5rem;">
                     <h4>ONLINEFIX</h4>
                     <p style="font-family: monospace; color: #999;">Expert electronics &amp; tablet repair in Guildford. Trusted, fast, and reliable service by Tomas.</p>
                     <div class="social-links" style="margin-top: 1rem; font-size: 1.5rem;">


### PR DESCRIPTION
The onlinefix-logo.webp image in the footer was unwanted. Removed the <img> tag from 