### PR TITLE
Fix Google reviews button to show reviews instead of write prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -812,7 +812,7 @@
                     </div>
                 </div>
                 <div style="text-align: center; margin-top: 2rem;">
-                    <a href="https://g.page/r/Cc0Vz3kdmt8bEBE/review" target="_blank" rel="noopener noreferrer"
+                    <a href="https://g.page/r/Cc0Vz3kdmt8bEBE/" target="_blank" rel="noopener noreferrer"
                         class="google-btn">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="24px" height="24px"
                             aria-hidden="true">


### PR DESCRIPTION
Changed /review to / in the g.page URL so the button takes users to the reviews listing rather than the write-a-review dialog.

https://claude.ai/code/session_01FVhhVczoRnT1av6sUzT8mX