### PR TITLE
Switch App Check from ReCaptchaV3Provider to ReCaptchaEnterpriseProvider

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -2358,7 +2358,7 @@
         // Initialize Firebase
         firebase.initializeApp(firebaseConfig);
         const appCheck = firebase.appCheck();
-        appCheck.activate('6LdZJRIsAAAAAOx4EZqupxMVvX4B3u3YlK5ez-3r', true);
+        appCheck.activate(new firebase.appCheck.ReCaptchaEnterpriseProvider('6LdZJRIsAAAAAOx4EZqupxMVvX4B3u3YlK5ez-3r'), true);
         const db = firebase.firestore();
         const auth = firebase.auth();
         const storage = firebase.storage();

--- a/new-repair/index.html
+++ b/new-repair/index.html
@@ -780,7 +780,7 @@
         // Initialize Firebase
         firebase.initializeApp(firebaseConfig);
         const appCheck = firebase.appCheck();
-        appCheck.activate('6LdZJRIsAAAAAOx4EZqupxMVvX4B3u3YlK5ez-3r', true);
+        appCheck.activate(new firebase.appCheck.ReCaptchaEnterpriseProvider('6LdZJRIsAAAAAOx4EZqupxMVvX4B3u3YlK5ez-3r'), true);
         const db = firebase.firestore();
         const storage = firebase.storage();
         const auth = firebase.auth();

--- a/track/index.html
+++ b/track/index.html
@@ -880,7 +880,7 @@
         // Initialize Firebase
         firebase.initializeApp(firebaseConfig);
         const appCheck = firebase.appCheck();
-        appCheck.activate('6LdZJRIsAAAAAOx4EZqupxMVvX4B3u3YlK5ez-3r', true);
+        appCheck.activate(new firebase.appCheck.ReCaptchaEnterpriseProvider('6LdZJRIsAAAAAOx4EZqupxMVvX4B3u3YlK5ez-3r'), true);
         const db = firebase.firestore();
 
         // Status definitions


### PR DESCRIPTION
The reCAPTCHA key is a reCAPTCHA Enterprise key (managed in Google Cloud Console), not a standard v3 key. Using the wrong provider type produces invalid tokens, causing auth/firebase-app-check-token-is-invalid errors.

https://claude.ai/code/session_01Xr4AKaNtScwfDS7WaSB8oG