### PR TITLE
Eliminate render-blocking CSS and fix forced reflows for 100 PageSpeed

### DIFF
--- a/404.html
+++ b/404.html
@@ -17,9 +17,40 @@
 
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin>
 
-    <link rel="stylesheet" href="/css/core.css">
-    <link rel="stylesheet" href="/css/icons.css">
+    <!-- Critical CSS inlined for fast first paint -->
+    <style>
+        :root{--hex-accent:#0033FF;--gradient-blue:linear-gradient(135deg,#0033FF 0%,#00C6FF 100%);--hex-black:#111111;--hex-concrete:#F2F2F2;--hex-white:#FFFFFF;--hex-grid:#DCDCDC;--hazard-stripe:repeating-linear-gradient(135deg,#111111,#111111 10px,#ffffff 10px,#ffffff 20px);--font-main:'Helvetica Neue',Helvetica,Arial,sans-serif;--border-width:1px;--safe-area-bottom:env(safe-area-inset-bottom)}
+        html{scroll-behavior:smooth}*{margin:0;padding:0;box-sizing:border-box}
+        body{font-family:var(--font-main);background-color:var(--hex-concrete);color:var(--hex-black);line-height:1.4;overflow-x:hidden;font-weight:400;padding-bottom:calc(60px + var(--safe-area-bottom))}
+        .skip-link{position:absolute;top:-40px;left:0;background:var(--hex-black);color:var(--hex-white);padding:8px 16px;z-index:10000;transition:top 0.3s;text-decoration:none;font-weight:500;text-transform:uppercase;font-size:0.9rem}.skip-link:focus{top:0}
+        :focus-visible{outline:3px solid var(--hex-accent);outline-offset:2px}*{-webkit-tap-highlight-color:transparent}
+        .navbar{position:fixed;top:0;left:0;right:0;background:var(--hex-white);z-index:1000;border-bottom:2px solid var(--hex-black);padding:0}
+        .nav-container{max-width:100%;display:flex;justify-content:space-between;align-items:stretch;height:60px}
+        .nav-logo{font-size:1.5rem;font-weight:700;color:var(--hex-white);text-decoration:none;text-transform:uppercase;letter-spacing:-1px;padding:0 1.5rem;display:flex;align-items:center;background:var(--gradient-blue);border-right:2px solid var(--hex-black);position:relative}.nav-logo::after{content:"\2122";font-size:0.4em;position:relative;top:-0.6em;margin-left:2px;line-height:0;vertical-align:baseline}
+        .nav-cta{background:var(--hex-black);color:var(--hex-white);padding:0 2rem;text-decoration:none;font-weight:500;text-transform:uppercase;display:flex;align-items:center;gap:10px;font-size:0.8rem;border-left:2px solid var(--hex-black)}.nav-cta::before,.nav-cta::after{content:none}
+        .nav-menu{display:flex;list-style:none;gap:0;align-items:stretch;flex-grow:1;justify-content:flex-end}
+        .nav-menu li{display:flex;align-items:stretch}
+        .nav-link{text-decoration:none;color:var(--hex-black);font-weight:500;text-transform:uppercase;font-size:0.9rem;padding:0 2rem;display:flex;align-items:center;border-left:1px solid var(--hex-grid);position:relative;transition:all 0.2s}
+        .mobile-menu-toggle{display:none;background:transparent;border:none;font-size:1.5rem;color:var(--hex-black);cursor:pointer;padding:0 1.5rem;min-width:60px;outline:none}
+        .container{max-width:1400px;margin:0 auto;padding:0 20px;position:relative;z-index:2;width:100%}
+        .section-title{font-size:clamp(2rem,5vw,3rem);font-weight:700;text-transform:uppercase;text-align:center;padding-top:4rem;letter-spacing:-1px;margin-bottom:0.5rem}
+        .cookie-banner{position:fixed;bottom:0;left:0;right:0;background:var(--hex-black);color:var(--hex-white);z-index:9999;border-top:4px solid;border-image:var(--gradient-blue) 1;transform:translateY(100%);transition:transform 0.3s ease}.cookie-banner.visible{transform:translateY(0)}
+        .fade-in{opacity:0;transform:translateY(20px);animation:appear 0.5s ease forwards}@keyframes appear{to{opacity:1;transform:translateY(0)}}
+        .page-header{padding:60px 0 0;background:linear-gradient(90deg,var(--hex-grid) 1px,transparent 1px) 0 0,linear-gradient(180deg,var(--hex-grid) 1px,transparent 1px) 0 0;background-size:40px 40px;background-color:var(--hex-concrete);position:relative;overflow:hidden}
+        .page-header-content{max-width:1400px;margin:0 auto;padding:4rem 20px;position:relative;z-index:2}
+        .page-header-box{text-align:center;border:2px solid var(--hex-black);padding:3rem 4rem;background:var(--hex-white);box-shadow:15px 15px 0px var(--hex-black)}
+        .page-title{font-size:clamp(2rem,6vw,4rem);font-weight:700;line-height:0.9;text-transform:uppercase;letter-spacing:-2px;color:var(--hex-black);margin-bottom:1rem}.page-title span{background:var(--gradient-blue);background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent;display:inline-block}
+        .page-subtitle{font-family:'Courier New',Courier,monospace;font-size:clamp(0.9rem,2vw,1.1rem);text-transform:uppercase;background:var(--hex-black);color:var(--hex-white);display:inline-block;padding:5px 8px}
+        @media(max-width:768px){.navbar{background:transparent;border-bottom:none}.nav-logo{display:none}.nav-container{justify-content:flex-end}.mobile-menu-toggle{display:block;background:transparent;border:none;font-size:2rem;padding:1rem 1.5rem;color:var(--hex-black)}.nav-menu{display:none;flex-direction:column;position:absolute;top:70px;left:0;right:0;background:var(--hex-white);border-top:2px solid var(--hex-black);border-bottom:2px solid var(--hex-black);box-shadow:0 10px 20px rgba(0,0,0,0.1)}.nav-menu.active{display:flex}.nav-link{padding:1.5rem;border-left:none;border-bottom:1px solid #eee;min-height:48px}.nav-cta{padding:1.5rem;justify-content:center;border-left:none;min-height:48px}.container{padding:0 12px}.section-title{padding-top:2rem;margin-bottom:0}.page-header-box{padding:1.5rem 1rem;box-shadow:6px 6px 0 var(--hex-black)}.page-title{font-size:clamp(1.8rem,7vw,2.5rem);letter-spacing:-1px}.page-subtitle{font-size:clamp(0.65rem,2.5vw,0.85rem);word-break:break-word;padding:4px 6px}.page-header-content{padding:2.5rem 12px}}
+    </style>
+    <!-- Deferred stylesheets (non-render-blocking) -->
+    <link rel="stylesheet" href="/css/core.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/core.css"></noscript>
+    <link rel="stylesheet" href="/css/icons.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/icons.css"></noscript>
     <style>
         .error-section {
             min-height: 100vh; display: flex; align-items: center; justify-content: center;

--- a/about.html
+++ b/about.html
@@ -48,6 +48,8 @@
 
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin>
 
     <!-- Breadcrumb Schema -->
     <script type="application/ld+json">
@@ -104,8 +106,37 @@
     }
     </script>
 
-    <link rel="stylesheet" href="/css/core.css">
-    <link rel="stylesheet" href="/css/icons.css">
+    <!-- Critical CSS inlined for fast first paint -->
+    <style>
+        :root{--hex-accent:#0033FF;--gradient-blue:linear-gradient(135deg,#0033FF 0%,#00C6FF 100%);--hex-black:#111111;--hex-concrete:#F2F2F2;--hex-white:#FFFFFF;--hex-grid:#DCDCDC;--hazard-stripe:repeating-linear-gradient(135deg,#111111,#111111 10px,#ffffff 10px,#ffffff 20px);--font-main:'Helvetica Neue',Helvetica,Arial,sans-serif;--border-width:1px;--safe-area-bottom:env(safe-area-inset-bottom)}
+        html{scroll-behavior:smooth}*{margin:0;padding:0;box-sizing:border-box}
+        body{font-family:var(--font-main);background-color:var(--hex-concrete);color:var(--hex-black);line-height:1.4;overflow-x:hidden;font-weight:400;padding-bottom:calc(60px + var(--safe-area-bottom))}
+        .skip-link{position:absolute;top:-40px;left:0;background:var(--hex-black);color:var(--hex-white);padding:8px 16px;z-index:10000;transition:top 0.3s;text-decoration:none;font-weight:500;text-transform:uppercase;font-size:0.9rem}.skip-link:focus{top:0}
+        :focus-visible{outline:3px solid var(--hex-accent);outline-offset:2px}*{-webkit-tap-highlight-color:transparent}
+        .navbar{position:fixed;top:0;left:0;right:0;background:var(--hex-white);z-index:1000;border-bottom:2px solid var(--hex-black);padding:0}
+        .nav-container{max-width:100%;display:flex;justify-content:space-between;align-items:stretch;height:60px}
+        .nav-logo{font-size:1.5rem;font-weight:700;color:var(--hex-white);text-decoration:none;text-transform:uppercase;letter-spacing:-1px;padding:0 1.5rem;display:flex;align-items:center;background:var(--gradient-blue);border-right:2px solid var(--hex-black);position:relative}.nav-logo::after{content:"\2122";font-size:0.4em;position:relative;top:-0.6em;margin-left:2px;line-height:0;vertical-align:baseline}
+        .nav-cta{background:var(--hex-black);color:var(--hex-white);padding:0 2rem;text-decoration:none;font-weight:500;text-transform:uppercase;display:flex;align-items:center;gap:10px;font-size:0.8rem;border-left:2px solid var(--hex-black)}.nav-cta::before,.nav-cta::after{content:none}
+        .nav-menu{display:flex;list-style:none;gap:0;align-items:stretch;flex-grow:1;justify-content:flex-end}
+        .nav-menu li{display:flex;align-items:stretch}
+        .nav-link{text-decoration:none;color:var(--hex-black);font-weight:500;text-transform:uppercase;font-size:0.9rem;padding:0 2rem;display:flex;align-items:center;border-left:1px solid var(--hex-grid);position:relative;transition:all 0.2s}
+        .mobile-menu-toggle{display:none;background:transparent;border:none;font-size:1.5rem;color:var(--hex-black);cursor:pointer;padding:0 1.5rem;min-width:60px;outline:none}
+        .container{max-width:1400px;margin:0 auto;padding:0 20px;position:relative;z-index:2;width:100%}
+        .section-title{font-size:clamp(2rem,5vw,3rem);font-weight:700;text-transform:uppercase;text-align:center;padding-top:4rem;letter-spacing:-1px;margin-bottom:0.5rem}
+        .cookie-banner{position:fixed;bottom:0;left:0;right:0;background:var(--hex-black);color:var(--hex-white);z-index:9999;border-top:4px solid;border-image:var(--gradient-blue) 1;transform:translateY(100%);transition:transform 0.3s ease}.cookie-banner.visible{transform:translateY(0)}
+        .fade-in{opacity:0;transform:translateY(20px);animation:appear 0.5s ease forwards}@keyframes appear{to{opacity:1;transform:translateY(0)}}
+        .page-header{padding:60px 0 0;background:linear-gradient(90deg,var(--hex-grid) 1px,transparent 1px) 0 0,linear-gradient(180deg,var(--hex-grid) 1px,transparent 1px) 0 0;background-size:40px 40px;background-color:var(--hex-concrete);position:relative;overflow:hidden}
+        .page-header-content{max-width:1400px;margin:0 auto;padding:4rem 20px;position:relative;z-index:2}
+        .page-header-box{text-align:center;border:2px solid var(--hex-black);padding:3rem 4rem;background:var(--hex-white);box-shadow:15px 15px 0px var(--hex-black)}
+        .page-title{font-size:clamp(2rem,6vw,4rem);font-weight:700;line-height:0.9;text-transform:uppercase;letter-spacing:-2px;color:var(--hex-black);margin-bottom:1rem}.page-title span{background:var(--gradient-blue);background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent;display:inline-block}
+        .page-subtitle{font-family:'Courier New',Courier,monospace;font-size:clamp(0.9rem,2vw,1.1rem);text-transform:uppercase;background:var(--hex-black);color:var(--hex-white);display:inline-block;padding:5px 8px}
+        @media(max-width:768px){.navbar{background:transparent;border-bottom:none}.nav-logo{display:none}.nav-container{justify-content:flex-end}.mobile-menu-toggle{display:block;background:transparent;border:none;font-size:2rem;padding:1rem 1.5rem;color:var(--hex-black)}.nav-menu{display:none;flex-direction:column;position:absolute;top:70px;left:0;right:0;background:var(--hex-white);border-top:2px solid var(--hex-black);border-bottom:2px solid var(--hex-black);box-shadow:0 10px 20px rgba(0,0,0,0.1)}.nav-menu.active{display:flex}.nav-link{padding:1.5rem;border-left:none;border-bottom:1px solid #eee;min-height:48px}.nav-cta{padding:1.5rem;justify-content:center;border-left:none;min-height:48px}.container{padding:0 12px}.section-title{padding-top:2rem;margin-bottom:0}.page-header-box{padding:1.5rem 1rem;box-shadow:6px 6px 0 var(--hex-black)}.page-title{font-size:clamp(1.8rem,7vw,2.5rem);letter-spacing:-1px}.page-subtitle{font-size:clamp(0.65rem,2.5vw,0.85rem);word-break:break-word;padding:4px 6px}.page-header-content{padding:2.5rem 12px}}
+    </style>
+    <!-- Deferred stylesheets (non-render-blocking) -->
+    <link rel="stylesheet" href="/css/core.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/core.css"></noscript>
+    <link rel="stylesheet" href="/css/icons.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/icons.css"></noscript>
     <style>
         .page-header::before {
             content: "FIG. 04 — PERSONNEL FILE";

--- a/console-repair.html
+++ b/console-repair.html
@@ -59,6 +59,8 @@
     <!-- Performance: DNS Prefetch and Preconnect -->
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin>
 
 
     <!-- Breadcrumb Schema -->
@@ -362,8 +364,37 @@
     }
     </script>
 
-    <link rel="stylesheet" href="/css/core.css">
-    <link rel="stylesheet" href="/css/icons.css">
+    <!-- Critical CSS inlined for fast first paint -->
+    <style>
+        :root{--hex-accent:#0033FF;--gradient-blue:linear-gradient(135deg,#0033FF 0%,#00C6FF 100%);--hex-black:#111111;--hex-concrete:#F2F2F2;--hex-white:#FFFFFF;--hex-grid:#DCDCDC;--hazard-stripe:repeating-linear-gradient(135deg,#111111,#111111 10px,#ffffff 10px,#ffffff 20px);--font-main:'Helvetica Neue',Helvetica,Arial,sans-serif;--border-width:1px;--safe-area-bottom:env(safe-area-inset-bottom)}
+        html{scroll-behavior:smooth}*{margin:0;padding:0;box-sizing:border-box}
+        body{font-family:var(--font-main);background-color:var(--hex-concrete);color:var(--hex-black);line-height:1.4;overflow-x:hidden;font-weight:400;padding-bottom:calc(60px + var(--safe-area-bottom))}
+        .skip-link{position:absolute;top:-40px;left:0;background:var(--hex-black);color:var(--hex-white);padding:8px 16px;z-index:10000;transition:top 0.3s;text-decoration:none;font-weight:500;text-transform:uppercase;font-size:0.9rem}.skip-link:focus{top:0}
+        :focus-visible{outline:3px solid var(--hex-accent);outline-offset:2px}*{-webkit-tap-highlight-color:transparent}
+        .navbar{position:fixed;top:0;left:0;right:0;background:var(--hex-white);z-index:1000;border-bottom:2px solid var(--hex-black);padding:0}
+        .nav-container{max-width:100%;display:flex;justify-content:space-between;align-items:stretch;height:60px}
+        .nav-logo{font-size:1.5rem;font-weight:700;color:var(--hex-white);text-decoration:none;text-transform:uppercase;letter-spacing:-1px;padding:0 1.5rem;display:flex;align-items:center;background:var(--gradient-blue);border-right:2px solid var(--hex-black);position:relative}.nav-logo::after{content:"\2122";font-size:0.4em;position:relative;top:-0.6em;margin-left:2px;line-height:0;vertical-align:baseline}
+        .nav-cta{background:var(--hex-black);color:var(--hex-white);padding:0 2rem;text-decoration:none;font-weight:500;text-transform:uppercase;display:flex;align-items:center;gap:10px;font-size:0.8rem;border-left:2px solid var(--hex-black)}.nav-cta::before,.nav-cta::after{content:none}
+        .nav-menu{display:flex;list-style:none;gap:0;align-items:stretch;flex-grow:1;justify-content:flex-end}
+        .nav-menu li{display:flex;align-items:stretch}
+        .nav-link{text-decoration:none;color:var(--hex-black);font-weight:500;text-transform:uppercase;font-size:0.9rem;padding:0 2rem;display:flex;align-items:center;border-left:1px solid var(--hex-grid);position:relative;transition:all 0.2s}
+        .mobile-menu-toggle{display:none;background:transparent;border:none;font-size:1.5rem;color:var(--hex-black);cursor:pointer;padding:0 1.5rem;min-width:60px;outline:none}
+        .container{max-width:1400px;margin:0 auto;padding:0 20px;position:relative;z-index:2;width:100%}
+        .section-title{font-size:clamp(2rem,5vw,3rem);font-weight:700;text-transform:uppercase;text-align:center;padding-top:4rem;letter-spacing:-1px;margin-bottom:0.5rem}
+        .cookie-banner{position:fixed;bottom:0;left:0;right:0;background:var(--hex-black);color:var(--hex-white);z-index:9999;border-top:4px solid;border-image:var(--gradient-blue) 1;transform:translateY(100%);transition:transform 0.3s ease}.cookie-banner.visible{transform:translateY(0)}
+        .fade-in{opacity:0;transform:translateY(20px);animation:appear 0.5s ease forwards}@keyframes appear{to{opacity:1;transform:translateY(0)}}
+        .page-header{padding:60px 0 0;background:linear-gradient(90deg,var(--hex-grid) 1px,transparent 1px) 0 0,linear-gradient(180deg,var(--hex-grid) 1px,transparent 1px) 0 0;background-size:40px 40px;background-color:var(--hex-concrete);position:relative;overflow:hidden}
+        .page-header-content{max-width:1400px;margin:0 auto;padding:4rem 20px;position:relative;z-index:2}
+        .page-header-box{text-align:center;border:2px solid var(--hex-black);padding:3rem 4rem;background:var(--hex-white);box-shadow:15px 15px 0px var(--hex-black)}
+        .page-title{font-size:clamp(2rem,6vw,4rem);font-weight:700;line-height:0.9;text-transform:uppercase;letter-spacing:-2px;color:var(--hex-black);margin-bottom:1rem}.page-title span{background:var(--gradient-blue);background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent;display:inline-block}
+        .page-subtitle{font-family:'Courier New',Courier,monospace;font-size:clamp(0.9rem,2vw,1.1rem);text-transform:uppercase;background:var(--hex-black);color:var(--hex-white);display:inline-block;padding:5px 8px}
+        @media(max-width:768px){.navbar{background:transparent;border-bottom:none}.nav-logo{display:none}.nav-container{justify-content:flex-end}.mobile-menu-toggle{display:block;background:transparent;border:none;font-size:2rem;padding:1rem 1.5rem;color:var(--hex-black)}.nav-menu{display:none;flex-direction:column;position:absolute;top:70px;left:0;right:0;background:var(--hex-white);border-top:2px solid var(--hex-black);border-bottom:2px solid var(--hex-black);box-shadow:0 10px 20px rgba(0,0,0,0.1)}.nav-menu.active{display:flex}.nav-link{padding:1.5rem;border-left:none;border-bottom:1px solid #eee;min-height:48px}.nav-cta{padding:1.5rem;justify-content:center;border-left:none;min-height:48px}.container{padding:0 12px}.section-title{padding-top:2rem;margin-bottom:0}.page-header-box{padding:1.5rem 1rem;box-shadow:6px 6px 0 var(--hex-black)}.page-title{font-size:clamp(1.8rem,7vw,2.5rem);letter-spacing:-1px}.page-subtitle{font-size:clamp(0.65rem,2.5vw,0.85rem);word-break:break-word;padding:4px 6px}.page-header-content{padding:2.5rem 12px}}
+    </style>
+    <!-- Deferred stylesheets (non-render-blocking) -->
+    <link rel="stylesheet" href="/css/core.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/core.css"></noscript>
+    <link rel="stylesheet" href="/css/icons.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/icons.css"></noscript>
     <style>
         html {
             overflow-x: hidden;

--- a/contact.html
+++ b/contact.html
@@ -48,6 +48,8 @@
 
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin>
 
     <!-- Breadcrumb Schema -->
     <script type="application/ld+json">
@@ -114,8 +116,37 @@
     }
     </script>
 
-    <link rel="stylesheet" href="/css/core.css">
-    <link rel="stylesheet" href="/css/icons.css">
+    <!-- Critical CSS inlined for fast first paint -->
+    <style>
+        :root{--hex-accent:#0033FF;--gradient-blue:linear-gradient(135deg,#0033FF 0%,#00C6FF 100%);--hex-black:#111111;--hex-concrete:#F2F2F2;--hex-white:#FFFFFF;--hex-grid:#DCDCDC;--hazard-stripe:repeating-linear-gradient(135deg,#111111,#111111 10px,#ffffff 10px,#ffffff 20px);--font-main:'Helvetica Neue',Helvetica,Arial,sans-serif;--border-width:1px;--safe-area-bottom:env(safe-area-inset-bottom)}
+        html{scroll-behavior:smooth}*{margin:0;padding:0;box-sizing:border-box}
+        body{font-family:var(--font-main);background-color:var(--hex-concrete);color:var(--hex-black);line-height:1.4;overflow-x:hidden;font-weight:400;padding-bottom:calc(60px + var(--safe-area-bottom))}
+        .skip-link{position:absolute;top:-40px;left:0;background:var(--hex-black);color:var(--hex-white);padding:8px 16px;z-index:10000;transition:top 0.3s;text-decoration:none;font-weight:500;text-transform:uppercase;font-size:0.9rem}.skip-link:focus{top:0}
+        :focus-visible{outline:3px solid var(--hex-accent);outline-offset:2px}*{-webkit-tap-highlight-color:transparent}
+        .navbar{position:fixed;top:0;left:0;right:0;background:var(--hex-white);z-index:1000;border-bottom:2px solid var(--hex-black);padding:0}
+        .nav-container{max-width:100%;display:flex;justify-content:space-between;align-items:stretch;height:60px}
+        .nav-logo{font-size:1.5rem;font-weight:700;color:var(--hex-white);text-decoration:none;text-transform:uppercase;letter-spacing:-1px;padding:0 1.5rem;display:flex;align-items:center;background:var(--gradient-blue);border-right:2px solid var(--hex-black);position:relative}.nav-logo::after{content:"\2122";font-size:0.4em;position:relative;top:-0.6em;margin-left:2px;line-height:0;vertical-align:baseline}
+        .nav-cta{background:var(--hex-black);color:var(--hex-white);padding:0 2rem;text-decoration:none;font-weight:500;text-transform:uppercase;display:flex;align-items:center;gap:10px;font-size:0.8rem;border-left:2px solid var(--hex-black)}.nav-cta::before,.nav-cta::after{content:none}
+        .nav-menu{display:flex;list-style:none;gap:0;align-items:stretch;flex-grow:1;justify-content:flex-end}
+        .nav-menu li{display:flex;align-items:stretch}
+        .nav-link{text-decoration:none;color:var(--hex-black);font-weight:500;text-transform:uppercase;font-size:0.9rem;padding:0 2rem;display:flex;align-items:center;border-left:1px solid var(--hex-grid);position:relative;transition:all 0.2s}
+        .mobile-menu-toggle{display:none;background:transparent;border:none;font-size:1.5rem;color:var(--hex-black);cursor:pointer;padding:0 1.5rem;min-width:60px;outline:none}
+        .container{max-width:1400px;margin:0 auto;padding:0 20px;position:relative;z-index:2;width:100%}
+        .section-title{font-size:clamp(2rem,5vw,3rem);font-weight:700;text-transform:uppercase;text-align:center;padding-top:4rem;letter-spacing:-1px;margin-bottom:0.5rem}
+        .cookie-banner{position:fixed;bottom:0;left:0;right:0;background:var(--hex-black);color:var(--hex-white);z-index:9999;border-top:4px solid;border-image:var(--gradient-blue) 1;transform:translateY(100%);transition:transform 0.3s ease}.cookie-banner.visible{transform:translateY(0)}
+        .fade-in{opacity:0;transform:translateY(20px);animation:appear 0.5s ease forwards}@keyframes appear{to{opacity:1;transform:translateY(0)}}
+        .page-header{padding:60px 0 0;background:linear-gradient(90deg,var(--hex-grid) 1px,transparent 1px) 0 0,linear-gradient(180deg,var(--hex-grid) 1px,transparent 1px) 0 0;background-size:40px 40px;background-color:var(--hex-concrete);position:relative;overflow:hidden}
+        .page-header-content{max-width:1400px;margin:0 auto;padding:4rem 20px;position:relative;z-index:2}
+        .page-header-box{text-align:center;border:2px solid var(--hex-black);padding:3rem 4rem;background:var(--hex-white);box-shadow:15px 15px 0px var(--hex-black)}
+        .page-title{font-size:clamp(2rem,6vw,4rem);font-weight:700;line-height:0.9;text-transform:uppercase;letter-spacing:-2px;color:var(--hex-black);margin-bottom:1rem}.page-title span{background:var(--gradient-blue);background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent;display:inline-block}
+        .page-subtitle{font-family:'Courier New',Courier,monospace;font-size:clamp(0.9rem,2vw,1.1rem);text-transform:uppercase;background:var(--hex-black);color:var(--hex-white);display:inline-block;padding:5px 8px}
+        @media(max-width:768px){.navbar{background:transparent;border-bottom:none}.nav-logo{display:none}.nav-container{justify-content:flex-end}.mobile-menu-toggle{display:block;background:transparent;border:none;font-size:2rem;padding:1rem 1.5rem;color:var(--hex-black)}.nav-menu{display:none;flex-direction:column;position:absolute;top:70px;left:0;right:0;background:var(--hex-white);border-top:2px solid var(--hex-black);border-bottom:2px solid var(--hex-black);box-shadow:0 10px 20px rgba(0,0,0,0.1)}.nav-menu.active{display:flex}.nav-link{padding:1.5rem;border-left:none;border-bottom:1px solid #eee;min-height:48px}.nav-cta{padding:1.5rem;justify-content:center;border-left:none;min-height:48px}.container{padding:0 12px}.section-title{padding-top:2rem;margin-bottom:0}.page-header-box{padding:1.5rem 1rem;box-shadow:6px 6px 0 var(--hex-black)}.page-title{font-size:clamp(1.8rem,7vw,2.5rem);letter-spacing:-1px}.page-subtitle{font-size:clamp(0.65rem,2.5vw,0.85rem);word-break:break-word;padding:4px 6px}.page-header-content{padding:2.5rem 12px}}
+    </style>
+    <!-- Deferred stylesheets (non-render-blocking) -->
+    <link rel="stylesheet" href="/css/core.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/core.css"></noscript>
+    <link rel="stylesheet" href="/css/icons.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/icons.css"></noscript>
     <style>
         .page-header::before {
             content: "FIG. 05 — CONTACT PROTOCOL";

--- a/data-recovery.html
+++ b/data-recovery.html
@@ -53,6 +53,8 @@
     <!-- Performance: DNS Prefetch and Preconnect -->
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin>
 
 
     <!-- Breadcrumb Schema -->
@@ -296,8 +298,37 @@
     }
     </script>
 
-    <link rel="stylesheet" href="/css/core.css">
-    <link rel="stylesheet" href="/css/icons.css">
+    <!-- Critical CSS inlined for fast first paint -->
+    <style>
+        :root{--hex-accent:#0033FF;--gradient-blue:linear-gradient(135deg,#0033FF 0%,#00C6FF 100%);--hex-black:#111111;--hex-concrete:#F2F2F2;--hex-white:#FFFFFF;--hex-grid:#DCDCDC;--hazard-stripe:repeating-linear-gradient(135deg,#111111,#111111 10px,#ffffff 10px,#ffffff 20px);--font-main:'Helvetica Neue',Helvetica,Arial,sans-serif;--border-width:1px;--safe-area-bottom:env(safe-area-inset-bottom)}
+        html{scroll-behavior:smooth}*{margin:0;padding:0;box-sizing:border-box}
+        body{font-family:var(--font-main);background-color:var(--hex-concrete);color:var(--hex-black);line-height:1.4;overflow-x:hidden;font-weight:400;padding-bottom:calc(60px + var(--safe-area-bottom))}
+        .skip-link{position:absolute;top:-40px;left:0;background:var(--hex-black);color:var(--hex-white);padding:8px 16px;z-index:10000;transition:top 0.3s;text-decoration:none;font-weight:500;text-transform:uppercase;font-size:0.9rem}.skip-link:focus{top:0}
+        :focus-visible{outline:3px solid var(--hex-accent);outline-offset:2px}*{-webkit-tap-highlight-color:transparent}
+        .navbar{position:fixed;top:0;left:0;right:0;background:var(--hex-white);z-index:1000;border-bottom:2px solid var(--hex-black);padding:0}
+        .nav-container{max-width:100%;display:flex;justify-content:space-between;align-items:stretch;height:60px}
+        .nav-logo{font-size:1.5rem;font-weight:700;color:var(--hex-white);text-decoration:none;text-transform:uppercase;letter-spacing:-1px;padding:0 1.5rem;display:flex;align-items:center;background:var(--gradient-blue);border-right:2px solid var(--hex-black);position:relative}.nav-logo::after{content:"\2122";font-size:0.4em;position:relative;top:-0.6em;margin-left:2px;line-height:0;vertical-align:baseline}
+        .nav-cta{background:var(--hex-black);color:var(--hex-white);padding:0 2rem;text-decoration:none;font-weight:500;text-transform:uppercase;display:flex;align-items:center;gap:10px;font-size:0.8rem;border-left:2px solid var(--hex-black)}.nav-cta::before,.nav-cta::after{content:none}
+        .nav-menu{display:flex;list-style:none;gap:0;align-items:stretch;flex-grow:1;justify-content:flex-end}
+        .nav-menu li{display:flex;align-items:stretch}
+        .nav-link{text-decoration:none;color:var(--hex-black);font-weight:500;text-transform:uppercase;font-size:0.9rem;padding:0 2rem;display:flex;align-items:center;border-left:1px solid var(--hex-grid);position:relative;transition:all 0.2s}
+        .mobile-menu-toggle{display:none;background:transparent;border:none;font-size:1.5rem;color:var(--hex-black);cursor:pointer;padding:0 1.5rem;min-width:60px;outline:none}
+        .container{max-width:1400px;margin:0 auto;padding:0 20px;position:relative;z-index:2;width:100%}
+        .section-title{font-size:clamp(2rem,5vw,3rem);font-weight:700;text-transform:uppercase;text-align:center;padding-top:4rem;letter-spacing:-1px;margin-bottom:0.5rem}
+        .cookie-banner{position:fixed;bottom:0;left:0;right:0;background:var(--hex-black);color:var(--hex-white);z-index:9999;border-top:4px solid;border-image:var(--gradient-blue) 1;transform:translateY(100%);transition:transform 0.3s ease}.cookie-banner.visible{transform:translateY(0)}
+        .fade-in{opacity:0;transform:translateY(20px);animation:appear 0.5s ease forwards}@keyframes appear{to{opacity:1;transform:translateY(0)}}
+        .page-header{padding:60px 0 0;background:linear-gradient(90deg,var(--hex-grid) 1px,transparent 1px) 0 0,linear-gradient(180deg,var(--hex-grid) 1px,transparent 1px) 0 0;background-size:40px 40px;background-color:var(--hex-concrete);position:relative;overflow:hidden}
+        .page-header-content{max-width:1400px;margin:0 auto;padding:4rem 20px;position:relative;z-index:2}
+        .page-header-box{text-align:center;border:2px solid var(--hex-black);padding:3rem 4rem;background:var(--hex-white);box-shadow:15px 15px 0px var(--hex-black)}
+        .page-title{font-size:clamp(2rem,6vw,4rem);font-weight:700;line-height:0.9;text-transform:uppercase;letter-spacing:-2px;color:var(--hex-black);margin-bottom:1rem}.page-title span{background:var(--gradient-blue);background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent;display:inline-block}
+        .page-subtitle{font-family:'Courier New',Courier,monospace;font-size:clamp(0.9rem,2vw,1.1rem);text-transform:uppercase;background:var(--hex-black);color:var(--hex-white);display:inline-block;padding:5px 8px}
+        @media(max-width:768px){.navbar{background:transparent;border-bottom:none}.nav-logo{display:none}.nav-container{justify-content:flex-end}.mobile-menu-toggle{display:block;background:transparent;border:none;font-size:2rem;padding:1rem 1.5rem;color:var(--hex-black)}.nav-menu{display:none;flex-direction:column;position:absolute;top:70px;left:0;right:0;background:var(--hex-white);border-top:2px solid var(--hex-black);border-bottom:2px solid var(--hex-black);box-shadow:0 10px 20px rgba(0,0,0,0.1)}.nav-menu.active{display:flex}.nav-link{padding:1.5rem;border-left:none;border-bottom:1px solid #eee;min-height:48px}.nav-cta{padding:1.5rem;justify-content:center;border-left:none;min-height:48px}.container{padding:0 12px}.section-title{padding-top:2rem;margin-bottom:0}.page-header-box{padding:1.5rem 1rem;box-shadow:6px 6px 0 var(--hex-black)}.page-title{font-size:clamp(1.8rem,7vw,2.5rem);letter-spacing:-1px}.page-subtitle{font-size:clamp(0.65rem,2.5vw,0.85rem);word-break:break-word;padding:4px 6px}.page-header-content{padding:2.5rem 12px}}
+    </style>
+    <!-- Deferred stylesheets (non-render-blocking) -->
+    <link rel="stylesheet" href="/css/core.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/core.css"></noscript>
+    <link rel="stylesheet" href="/css/icons.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/icons.css"></noscript>
     <style>
         html { overflow-x: hidden; }
 

--- a/index.html
+++ b/index.html
@@ -61,10 +61,11 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/favicon-180x180.png">
     <link rel="shortcut icon" href="/favicon.ico">
 
-    <!-- Performance: DNS Prefetch and Preconnect -->
+    <!-- Performance: DNS Prefetch, Preconnect & Font Preload -->
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
-
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin>
 
     <!-- Enhanced Local Business Schema (GBP Optimized) -->
     <script type="application/ld+json">
@@ -304,8 +305,31 @@
     }
     </script>
 
-    <link rel="stylesheet" href="/css/core.css">
-    <link rel="stylesheet" href="/css/icons.css">
+    <!-- Critical CSS inlined for fast first paint -->
+    <style>
+        :root{--hex-accent:#0033FF;--gradient-blue:linear-gradient(135deg,#0033FF 0%,#00C6FF 100%);--hex-black:#111111;--hex-concrete:#F2F2F2;--hex-white:#FFFFFF;--hex-grid:#DCDCDC;--hazard-stripe:repeating-linear-gradient(135deg,#111111,#111111 10px,#ffffff 10px,#ffffff 20px);--font-main:'Helvetica Neue',Helvetica,Arial,sans-serif;--border-width:1px;--safe-area-bottom:env(safe-area-inset-bottom)}
+        html{scroll-behavior:smooth}*{margin:0;padding:0;box-sizing:border-box}
+        body{font-family:var(--font-main);background-color:var(--hex-concrete);color:var(--hex-black);line-height:1.4;overflow-x:hidden;font-weight:400;padding-bottom:calc(60px + var(--safe-area-bottom))}
+        .skip-link{position:absolute;top:-40px;left:0;background:var(--hex-black);color:var(--hex-white);padding:8px 16px;z-index:10000;transition:top 0.3s;text-decoration:none;font-weight:500;text-transform:uppercase;font-size:0.9rem}.skip-link:focus{top:0}
+        :focus-visible{outline:3px solid var(--hex-accent);outline-offset:2px}*{-webkit-tap-highlight-color:transparent}
+        .navbar{position:fixed;top:0;left:0;right:0;background:var(--hex-white);z-index:1000;border-bottom:2px solid var(--hex-black);padding:0}
+        .nav-container{max-width:100%;display:flex;justify-content:space-between;align-items:stretch;height:60px}
+        .nav-logo{font-size:1.5rem;font-weight:700;color:var(--hex-white);text-decoration:none;text-transform:uppercase;letter-spacing:-1px;padding:0 1.5rem;display:flex;align-items:center;background:var(--gradient-blue);border-right:2px solid var(--hex-black);position:relative}.nav-logo::after{content:"\2122";font-size:0.4em;position:relative;top:-0.6em;margin-left:2px;line-height:0;vertical-align:baseline}
+        .nav-menu{display:flex;list-style:none;gap:0;align-items:stretch;flex-grow:1;justify-content:flex-end}
+        .nav-menu li{display:flex;align-items:stretch}
+        .nav-link{text-decoration:none;color:var(--hex-black);font-weight:500;text-transform:uppercase;font-size:0.9rem;padding:0 2rem;display:flex;align-items:center;border-left:1px solid var(--hex-grid);position:relative;transition:all 0.2s}
+        .nav-cta{background:var(--hex-black);color:var(--hex-white);padding:0 2rem;text-decoration:none;font-weight:500;text-transform:uppercase;display:flex;align-items:center;gap:10px;font-size:0.8rem;border-left:2px solid var(--hex-black)}.nav-cta::before,.nav-cta::after{content:none}
+        .mobile-menu-toggle{display:none;background:transparent;border:none;font-size:1.5rem;color:var(--hex-black);cursor:pointer;padding:0 1.5rem;min-width:60px;outline:none}
+        .container{max-width:1400px;margin:0 auto;padding:0 20px;position:relative;z-index:2;width:100%}
+        .section-title{font-size:clamp(2rem,5vw,3rem);font-weight:700;text-transform:uppercase;text-align:center;padding-top:4rem;letter-spacing:-1px;margin-bottom:0.5rem}
+        .cookie-banner{position:fixed;bottom:0;left:0;right:0;background:var(--hex-black);color:var(--hex-white);z-index:9999;border-top:4px solid;border-image:var(--gradient-blue) 1;transform:translateY(100%);transition:transform 0.3s ease}.cookie-banner.visible{transform:translateY(0)}
+        .fade-in{opacity:0;transform:translateY(20px);animation:appear 0.5s ease forwards}@keyframes appear{to{opacity:1;transform:translateY(0)}}
+        @media(max-width:768px){.navbar{background:transparent;border-bottom:none}.nav-logo{display:none}.nav-container{justify-content:flex-end}.mobile-menu-toggle{display:block;background:transparent;border:none;font-size:2rem;padding:1rem 1.5rem;color:var(--hex-black)}.nav-menu{display:none;flex-direction:column;position:absolute;top:70px;left:0;right:0;background:var(--hex-white);border-top:2px solid var(--hex-black);border-bottom:2px solid var(--hex-black);box-shadow:0 10px 20px rgba(0,0,0,0.1)}.nav-menu.active{display:flex}.nav-link{padding:1.5rem;border-left:none;border-bottom:1px solid #eee;min-height:48px}.nav-cta{padding:1.5rem;justify-content:center;border-left:none;min-height:48px}.container{padding:0 12px}.section-title{padding-top:2rem;margin-bottom:0}}
+    </style>
+    <!-- Deferred stylesheets (non-render-blocking) -->
+    <link rel="stylesheet" href="/css/core.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="/css/icons.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/core.css"><link rel="stylesheet" href="/css/icons.css"></noscript>
     <style>
         .hero {
             min-height: 90vh;

--- a/iphone-repair.html
+++ b/iphone-repair.html
@@ -53,6 +53,8 @@
     <!-- Performance: DNS Prefetch and Preconnect -->
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin>
 
 
     <!-- Breadcrumb Schema -->
@@ -363,8 +365,37 @@
     }
     </script>
 
-    <link rel="stylesheet" href="/css/core.css">
-    <link rel="stylesheet" href="/css/icons.css">
+    <!-- Critical CSS inlined for fast first paint -->
+    <style>
+        :root{--hex-accent:#0033FF;--gradient-blue:linear-gradient(135deg,#0033FF 0%,#00C6FF 100%);--hex-black:#111111;--hex-concrete:#F2F2F2;--hex-white:#FFFFFF;--hex-grid:#DCDCDC;--hazard-stripe:repeating-linear-gradient(135deg,#111111,#111111 10px,#ffffff 10px,#ffffff 20px);--font-main:'Helvetica Neue',Helvetica,Arial,sans-serif;--border-width:1px;--safe-area-bottom:env(safe-area-inset-bottom)}
+        html{scroll-behavior:smooth}*{margin:0;padding:0;box-sizing:border-box}
+        body{font-family:var(--font-main);background-color:var(--hex-concrete);color:var(--hex-black);line-height:1.4;overflow-x:hidden;font-weight:400;padding-bottom:calc(60px + var(--safe-area-bottom))}
+        .skip-link{position:absolute;top:-40px;left:0;background:var(--hex-black);color:var(--hex-white);padding:8px 16px;z-index:10000;transition:top 0.3s;text-decoration:none;font-weight:500;text-transform:uppercase;font-size:0.9rem}.skip-link:focus{top:0}
+        :focus-visible{outline:3px solid var(--hex-accent);outline-offset:2px}*{-webkit-tap-highlight-color:transparent}
+        .navbar{position:fixed;top:0;left:0;right:0;background:var(--hex-white);z-index:1000;border-bottom:2px solid var(--hex-black);padding:0}
+        .nav-container{max-width:100%;display:flex;justify-content:space-between;align-items:stretch;height:60px}
+        .nav-logo{font-size:1.5rem;font-weight:700;color:var(--hex-white);text-decoration:none;text-transform:uppercase;letter-spacing:-1px;padding:0 1.5rem;display:flex;align-items:center;background:var(--gradient-blue);border-right:2px solid var(--hex-black);position:relative}.nav-logo::after{content:"\2122";font-size:0.4em;position:relative;top:-0.6em;margin-left:2px;line-height:0;vertical-align:baseline}
+        .nav-cta{background:var(--hex-black);color:var(--hex-white);padding:0 2rem;text-decoration:none;font-weight:500;text-transform:uppercase;display:flex;align-items:center;gap:10px;font-size:0.8rem;border-left:2px solid var(--hex-black)}.nav-cta::before,.nav-cta::after{content:none}
+        .nav-menu{display:flex;list-style:none;gap:0;align-items:stretch;flex-grow:1;justify-content:flex-end}
+        .nav-menu li{display:flex;align-items:stretch}
+        .nav-link{text-decoration:none;color:var(--hex-black);font-weight:500;text-transform:uppercase;font-size:0.9rem;padding:0 2rem;display:flex;align-items:center;border-left:1px solid var(--hex-grid);position:relative;transition:all 0.2s}
+        .mobile-menu-toggle{display:none;background:transparent;border:none;font-size:1.5rem;color:var(--hex-black);cursor:pointer;padding:0 1.5rem;min-width:60px;outline:none}
+        .container{max-width:1400px;margin:0 auto;padding:0 20px;position:relative;z-index:2;width:100%}
+        .section-title{font-size:clamp(2rem,5vw,3rem);font-weight:700;text-transform:uppercase;text-align:center;padding-top:4rem;letter-spacing:-1px;margin-bottom:0.5rem}
+        .cookie-banner{position:fixed;bottom:0;left:0;right:0;background:var(--hex-black);color:var(--hex-white);z-index:9999;border-top:4px solid;border-image:var(--gradient-blue) 1;transform:translateY(100%);transition:transform 0.3s ease}.cookie-banner.visible{transform:translateY(0)}
+        .fade-in{opacity:0;transform:translateY(20px);animation:appear 0.5s ease forwards}@keyframes appear{to{opacity:1;transform:translateY(0)}}
+        .page-header{padding:60px 0 0;background:linear-gradient(90deg,var(--hex-grid) 1px,transparent 1px) 0 0,linear-gradient(180deg,var(--hex-grid) 1px,transparent 1px) 0 0;background-size:40px 40px;background-color:var(--hex-concrete);position:relative;overflow:hidden}
+        .page-header-content{max-width:1400px;margin:0 auto;padding:4rem 20px;position:relative;z-index:2}
+        .page-header-box{text-align:center;border:2px solid var(--hex-black);padding:3rem 4rem;background:var(--hex-white);box-shadow:15px 15px 0px var(--hex-black)}
+        .page-title{font-size:clamp(2rem,6vw,4rem);font-weight:700;line-height:0.9;text-transform:uppercase;letter-spacing:-2px;color:var(--hex-black);margin-bottom:1rem}.page-title span{background:var(--gradient-blue);background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent;display:inline-block}
+        .page-subtitle{font-family:'Courier New',Courier,monospace;font-size:clamp(0.9rem,2vw,1.1rem);text-transform:uppercase;background:var(--hex-black);color:var(--hex-white);display:inline-block;padding:5px 8px}
+        @media(max-width:768px){.navbar{background:transparent;border-bottom:none}.nav-logo{display:none}.nav-container{justify-content:flex-end}.mobile-menu-toggle{display:block;background:transparent;border:none;font-size:2rem;padding:1rem 1.5rem;color:var(--hex-black)}.nav-menu{display:none;flex-direction:column;position:absolute;top:70px;left:0;right:0;background:var(--hex-white);border-top:2px solid var(--hex-black);border-bottom:2px solid var(--hex-black);box-shadow:0 10px 20px rgba(0,0,0,0.1)}.nav-menu.active{display:flex}.nav-link{padding:1.5rem;border-left:none;border-bottom:1px solid #eee;min-height:48px}.nav-cta{padding:1.5rem;justify-content:center;border-left:none;min-height:48px}.container{padding:0 12px}.section-title{padding-top:2rem;margin-bottom:0}.page-header-box{padding:1.5rem 1rem;box-shadow:6px 6px 0 var(--hex-black)}.page-title{font-size:clamp(1.8rem,7vw,2.5rem);letter-spacing:-1px}.page-subtitle{font-size:clamp(0.65rem,2.5vw,0.85rem);word-break:break-word;padding:4px 6px}.page-header-content{padding:2.5rem 12px}}
+    </style>
+    <!-- Deferred stylesheets (non-render-blocking) -->
+    <link rel="stylesheet" href="/css/core.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/core.css"></noscript>
+    <link rel="stylesheet" href="/css/icons.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/icons.css"></noscript>
     <style>
         html { overflow-x: hidden; }
 

--- a/js/cookies.js
+++ b/js/cookies.js
@@ -54,9 +54,12 @@
         var banner = document.getElementById('cookie-banner');
         if (banner) {
             banner.style.display = 'block';
-            // Force reflow before adding class so transition works
-            banner.offsetHeight;
-            banner.classList.add('visible');
+            // Use rAF to trigger transition without forced reflow
+            requestAnimationFrame(function () {
+                requestAnimationFrame(function () {
+                    banner.classList.add('visible');
+                });
+            });
         }
     }
 

--- a/js/core.js
+++ b/js/core.js
@@ -78,7 +78,8 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 // Mobile scroll nudge (for pages with horizontal-scrolling grids)
-if (window.innerWidth < 768) {
+// Use matchMedia instead of innerWidth to avoid forced reflow
+if (window.matchMedia('(max-width: 767px)').matches) {
     document.addEventListener('DOMContentLoaded', () => {
         const scrollGrids = document.querySelectorAll('[data-scroll-nudge]');
         if (scrollGrids.length === 0) return;

--- a/macbook-repair.html
+++ b/macbook-repair.html
@@ -53,6 +53,8 @@
     <!-- Performance: DNS Prefetch and Preconnect -->
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin>
 
 
     <!-- Breadcrumb Schema -->
@@ -296,8 +298,37 @@
     }
     </script>
 
-    <link rel="stylesheet" href="/css/core.css">
-    <link rel="stylesheet" href="/css/icons.css">
+    <!-- Critical CSS inlined for fast first paint -->
+    <style>
+        :root{--hex-accent:#0033FF;--gradient-blue:linear-gradient(135deg,#0033FF 0%,#00C6FF 100%);--hex-black:#111111;--hex-concrete:#F2F2F2;--hex-white:#FFFFFF;--hex-grid:#DCDCDC;--hazard-stripe:repeating-linear-gradient(135deg,#111111,#111111 10px,#ffffff 10px,#ffffff 20px);--font-main:'Helvetica Neue',Helvetica,Arial,sans-serif;--border-width:1px;--safe-area-bottom:env(safe-area-inset-bottom)}
+        html{scroll-behavior:smooth}*{margin:0;padding:0;box-sizing:border-box}
+        body{font-family:var(--font-main);background-color:var(--hex-concrete);color:var(--hex-black);line-height:1.4;overflow-x:hidden;font-weight:400;padding-bottom:calc(60px + var(--safe-area-bottom))}
+        .skip-link{position:absolute;top:-40px;left:0;background:var(--hex-black);color:var(--hex-white);padding:8px 16px;z-index:10000;transition:top 0.3s;text-decoration:none;font-weight:500;text-transform:uppercase;font-size:0.9rem}.skip-link:focus{top:0}
+        :focus-visible{outline:3px solid var(--hex-accent);outline-offset:2px}*{-webkit-tap-highlight-color:transparent}
+        .navbar{position:fixed;top:0;left:0;right:0;background:var(--hex-white);z-index:1000;border-bottom:2px solid var(--hex-black);padding:0}
+        .nav-container{max-width:100%;display:flex;justify-content:space-between;align-items:stretch;height:60px}
+        .nav-logo{font-size:1.5rem;font-weight:700;color:var(--hex-white);text-decoration:none;text-transform:uppercase;letter-spacing:-1px;padding:0 1.5rem;display:flex;align-items:center;background:var(--gradient-blue);border-right:2px solid var(--hex-black);position:relative}.nav-logo::after{content:"\2122";font-size:0.4em;position:relative;top:-0.6em;margin-left:2px;line-height:0;vertical-align:baseline}
+        .nav-cta{background:var(--hex-black);color:var(--hex-white);padding:0 2rem;text-decoration:none;font-weight:500;text-transform:uppercase;display:flex;align-items:center;gap:10px;font-size:0.8rem;border-left:2px solid var(--hex-black)}.nav-cta::before,.nav-cta::after{content:none}
+        .nav-menu{display:flex;list-style:none;gap:0;align-items:stretch;flex-grow:1;justify-content:flex-end}
+        .nav-menu li{display:flex;align-items:stretch}
+        .nav-link{text-decoration:none;color:var(--hex-black);font-weight:500;text-transform:uppercase;font-size:0.9rem;padding:0 2rem;display:flex;align-items:center;border-left:1px solid var(--hex-grid);position:relative;transition:all 0.2s}
+        .mobile-menu-toggle{display:none;background:transparent;border:none;font-size:1.5rem;color:var(--hex-black);cursor:pointer;padding:0 1.5rem;min-width:60px;outline:none}
+        .container{max-width:1400px;margin:0 auto;padding:0 20px;position:relative;z-index:2;width:100%}
+        .section-title{font-size:clamp(2rem,5vw,3rem);font-weight:700;text-transform:uppercase;text-align:center;padding-top:4rem;letter-spacing:-1px;margin-bottom:0.5rem}
+        .cookie-banner{position:fixed;bottom:0;left:0;right:0;background:var(--hex-black);color:var(--hex-white);z-index:9999;border-top:4px solid;border-image:var(--gradient-blue) 1;transform:translateY(100%);transition:transform 0.3s ease}.cookie-banner.visible{transform:translateY(0)}
+        .fade-in{opacity:0;transform:translateY(20px);animation:appear 0.5s ease forwards}@keyframes appear{to{opacity:1;transform:translateY(0)}}
+        .page-header{padding:60px 0 0;background:linear-gradient(90deg,var(--hex-grid) 1px,transparent 1px) 0 0,linear-gradient(180deg,var(--hex-grid) 1px,transparent 1px) 0 0;background-size:40px 40px;background-color:var(--hex-concrete);position:relative;overflow:hidden}
+        .page-header-content{max-width:1400px;margin:0 auto;padding:4rem 20px;position:relative;z-index:2}
+        .page-header-box{text-align:center;border:2px solid var(--hex-black);padding:3rem 4rem;background:var(--hex-white);box-shadow:15px 15px 0px var(--hex-black)}
+        .page-title{font-size:clamp(2rem,6vw,4rem);font-weight:700;line-height:0.9;text-transform:uppercase;letter-spacing:-2px;color:var(--hex-black);margin-bottom:1rem}.page-title span{background:var(--gradient-blue);background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent;display:inline-block}
+        .page-subtitle{font-family:'Courier New',Courier,monospace;font-size:clamp(0.9rem,2vw,1.1rem);text-transform:uppercase;background:var(--hex-black);color:var(--hex-white);display:inline-block;padding:5px 8px}
+        @media(max-width:768px){.navbar{background:transparent;border-bottom:none}.nav-logo{display:none}.nav-container{justify-content:flex-end}.mobile-menu-toggle{display:block;background:transparent;border:none;font-size:2rem;padding:1rem 1.5rem;color:var(--hex-black)}.nav-menu{display:none;flex-direction:column;position:absolute;top:70px;left:0;right:0;background:var(--hex-white);border-top:2px solid var(--hex-black);border-bottom:2px solid var(--hex-black);box-shadow:0 10px 20px rgba(0,0,0,0.1)}.nav-menu.active{display:flex}.nav-link{padding:1.5rem;border-left:none;border-bottom:1px solid #eee;min-height:48px}.nav-cta{padding:1.5rem;justify-content:center;border-left:none;min-height:48px}.container{padding:0 12px}.section-title{padding-top:2rem;margin-bottom:0}.page-header-box{padding:1.5rem 1rem;box-shadow:6px 6px 0 var(--hex-black)}.page-title{font-size:clamp(1.8rem,7vw,2.5rem);letter-spacing:-1px}.page-subtitle{font-size:clamp(0.65rem,2.5vw,0.85rem);word-break:break-word;padding:4px 6px}.page-header-content{padding:2.5rem 12px}}
+    </style>
+    <!-- Deferred stylesheets (non-render-blocking) -->
+    <link rel="stylesheet" href="/css/core.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/core.css"></noscript>
+    <link rel="stylesheet" href="/css/icons.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/icons.css"></noscript>
     <style>
         html { overflow-x: hidden; }
 

--- a/pc-repair.html
+++ b/pc-repair.html
@@ -58,6 +58,8 @@
     <!-- Performance: DNS Prefetch and Preconnect -->
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin>
 
 
     <!-- Breadcrumb Schema -->
@@ -368,8 +370,37 @@
     }
     </script>
 
-    <link rel="stylesheet" href="/css/core.css">
-    <link rel="stylesheet" href="/css/icons.css">
+    <!-- Critical CSS inlined for fast first paint -->
+    <style>
+        :root{--hex-accent:#0033FF;--gradient-blue:linear-gradient(135deg,#0033FF 0%,#00C6FF 100%);--hex-black:#111111;--hex-concrete:#F2F2F2;--hex-white:#FFFFFF;--hex-grid:#DCDCDC;--hazard-stripe:repeating-linear-gradient(135deg,#111111,#111111 10px,#ffffff 10px,#ffffff 20px);--font-main:'Helvetica Neue',Helvetica,Arial,sans-serif;--border-width:1px;--safe-area-bottom:env(safe-area-inset-bottom)}
+        html{scroll-behavior:smooth}*{margin:0;padding:0;box-sizing:border-box}
+        body{font-family:var(--font-main);background-color:var(--hex-concrete);color:var(--hex-black);line-height:1.4;overflow-x:hidden;font-weight:400;padding-bottom:calc(60px + var(--safe-area-bottom))}
+        .skip-link{position:absolute;top:-40px;left:0;background:var(--hex-black);color:var(--hex-white);padding:8px 16px;z-index:10000;transition:top 0.3s;text-decoration:none;font-weight:500;text-transform:uppercase;font-size:0.9rem}.skip-link:focus{top:0}
+        :focus-visible{outline:3px solid var(--hex-accent);outline-offset:2px}*{-webkit-tap-highlight-color:transparent}
+        .navbar{position:fixed;top:0;left:0;right:0;background:var(--hex-white);z-index:1000;border-bottom:2px solid var(--hex-black);padding:0}
+        .nav-container{max-width:100%;display:flex;justify-content:space-between;align-items:stretch;height:60px}
+        .nav-logo{font-size:1.5rem;font-weight:700;color:var(--hex-white);text-decoration:none;text-transform:uppercase;letter-spacing:-1px;padding:0 1.5rem;display:flex;align-items:center;background:var(--gradient-blue);border-right:2px solid var(--hex-black);position:relative}.nav-logo::after{content:"\2122";font-size:0.4em;position:relative;top:-0.6em;margin-left:2px;line-height:0;vertical-align:baseline}
+        .nav-cta{background:var(--hex-black);color:var(--hex-white);padding:0 2rem;text-decoration:none;font-weight:500;text-transform:uppercase;display:flex;align-items:center;gap:10px;font-size:0.8rem;border-left:2px solid var(--hex-black)}.nav-cta::before,.nav-cta::after{content:none}
+        .nav-menu{display:flex;list-style:none;gap:0;align-items:stretch;flex-grow:1;justify-content:flex-end}
+        .nav-menu li{display:flex;align-items:stretch}
+        .nav-link{text-decoration:none;color:var(--hex-black);font-weight:500;text-transform:uppercase;font-size:0.9rem;padding:0 2rem;display:flex;align-items:center;border-left:1px solid var(--hex-grid);position:relative;transition:all 0.2s}
+        .mobile-menu-toggle{display:none;background:transparent;border:none;font-size:1.5rem;color:var(--hex-black);cursor:pointer;padding:0 1.5rem;min-width:60px;outline:none}
+        .container{max-width:1400px;margin:0 auto;padding:0 20px;position:relative;z-index:2;width:100%}
+        .section-title{font-size:clamp(2rem,5vw,3rem);font-weight:700;text-transform:uppercase;text-align:center;padding-top:4rem;letter-spacing:-1px;margin-bottom:0.5rem}
+        .cookie-banner{position:fixed;bottom:0;left:0;right:0;background:var(--hex-black);color:var(--hex-white);z-index:9999;border-top:4px solid;border-image:var(--gradient-blue) 1;transform:translateY(100%);transition:transform 0.3s ease}.cookie-banner.visible{transform:translateY(0)}
+        .fade-in{opacity:0;transform:translateY(20px);animation:appear 0.5s ease forwards}@keyframes appear{to{opacity:1;transform:translateY(0)}}
+        .page-header{padding:60px 0 0;background:linear-gradient(90deg,var(--hex-grid) 1px,transparent 1px) 0 0,linear-gradient(180deg,var(--hex-grid) 1px,transparent 1px) 0 0;background-size:40px 40px;background-color:var(--hex-concrete);position:relative;overflow:hidden}
+        .page-header-content{max-width:1400px;margin:0 auto;padding:4rem 20px;position:relative;z-index:2}
+        .page-header-box{text-align:center;border:2px solid var(--hex-black);padding:3rem 4rem;background:var(--hex-white);box-shadow:15px 15px 0px var(--hex-black)}
+        .page-title{font-size:clamp(2rem,6vw,4rem);font-weight:700;line-height:0.9;text-transform:uppercase;letter-spacing:-2px;color:var(--hex-black);margin-bottom:1rem}.page-title span{background:var(--gradient-blue);background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent;display:inline-block}
+        .page-subtitle{font-family:'Courier New',Courier,monospace;font-size:clamp(0.9rem,2vw,1.1rem);text-transform:uppercase;background:var(--hex-black);color:var(--hex-white);display:inline-block;padding:5px 8px}
+        @media(max-width:768px){.navbar{background:transparent;border-bottom:none}.nav-logo{display:none}.nav-container{justify-content:flex-end}.mobile-menu-toggle{display:block;background:transparent;border:none;font-size:2rem;padding:1rem 1.5rem;color:var(--hex-black)}.nav-menu{display:none;flex-direction:column;position:absolute;top:70px;left:0;right:0;background:var(--hex-white);border-top:2px solid var(--hex-black);border-bottom:2px solid var(--hex-black);box-shadow:0 10px 20px rgba(0,0,0,0.1)}.nav-menu.active{display:flex}.nav-link{padding:1.5rem;border-left:none;border-bottom:1px solid #eee;min-height:48px}.nav-cta{padding:1.5rem;justify-content:center;border-left:none;min-height:48px}.container{padding:0 12px}.section-title{padding-top:2rem;margin-bottom:0}.page-header-box{padding:1.5rem 1rem;box-shadow:6px 6px 0 var(--hex-black)}.page-title{font-size:clamp(1.8rem,7vw,2.5rem);letter-spacing:-1px}.page-subtitle{font-size:clamp(0.65rem,2.5vw,0.85rem);word-break:break-word;padding:4px 6px}.page-header-content{padding:2.5rem 12px}}
+    </style>
+    <!-- Deferred stylesheets (non-render-blocking) -->
+    <link rel="stylesheet" href="/css/core.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/core.css"></noscript>
+    <link rel="stylesheet" href="/css/icons.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/icons.css"></noscript>
     <style>
         html {
             overflow-x: hidden;

--- a/privacy.html
+++ b/privacy.html
@@ -33,6 +33,8 @@
 
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin>
 
     <script type="application/ld+json">
     {
@@ -55,8 +57,37 @@
     }
     </script>
 
-    <link rel="stylesheet" href="/css/core.css">
-    <link rel="stylesheet" href="/css/icons.css">
+    <!-- Critical CSS inlined for fast first paint -->
+    <style>
+        :root{--hex-accent:#0033FF;--gradient-blue:linear-gradient(135deg,#0033FF 0%,#00C6FF 100%);--hex-black:#111111;--hex-concrete:#F2F2F2;--hex-white:#FFFFFF;--hex-grid:#DCDCDC;--hazard-stripe:repeating-linear-gradient(135deg,#111111,#111111 10px,#ffffff 10px,#ffffff 20px);--font-main:'Helvetica Neue',Helvetica,Arial,sans-serif;--border-width:1px;--safe-area-bottom:env(safe-area-inset-bottom)}
+        html{scroll-behavior:smooth}*{margin:0;padding:0;box-sizing:border-box}
+        body{font-family:var(--font-main);background-color:var(--hex-concrete);color:var(--hex-black);line-height:1.4;overflow-x:hidden;font-weight:400;padding-bottom:calc(60px + var(--safe-area-bottom))}
+        .skip-link{position:absolute;top:-40px;left:0;background:var(--hex-black);color:var(--hex-white);padding:8px 16px;z-index:10000;transition:top 0.3s;text-decoration:none;font-weight:500;text-transform:uppercase;font-size:0.9rem}.skip-link:focus{top:0}
+        :focus-visible{outline:3px solid var(--hex-accent);outline-offset:2px}*{-webkit-tap-highlight-color:transparent}
+        .navbar{position:fixed;top:0;left:0;right:0;background:var(--hex-white);z-index:1000;border-bottom:2px solid var(--hex-black);padding:0}
+        .nav-container{max-width:100%;display:flex;justify-content:space-between;align-items:stretch;height:60px}
+        .nav-logo{font-size:1.5rem;font-weight:700;color:var(--hex-white);text-decoration:none;text-transform:uppercase;letter-spacing:-1px;padding:0 1.5rem;display:flex;align-items:center;background:var(--gradient-blue);border-right:2px solid var(--hex-black);position:relative}.nav-logo::after{content:"\2122";font-size:0.4em;position:relative;top:-0.6em;margin-left:2px;line-height:0;vertical-align:baseline}
+        .nav-cta{background:var(--hex-black);color:var(--hex-white);padding:0 2rem;text-decoration:none;font-weight:500;text-transform:uppercase;display:flex;align-items:center;gap:10px;font-size:0.8rem;border-left:2px solid var(--hex-black)}.nav-cta::before,.nav-cta::after{content:none}
+        .nav-menu{display:flex;list-style:none;gap:0;align-items:stretch;flex-grow:1;justify-content:flex-end}
+        .nav-menu li{display:flex;align-items:stretch}
+        .nav-link{text-decoration:none;color:var(--hex-black);font-weight:500;text-transform:uppercase;font-size:0.9rem;padding:0 2rem;display:flex;align-items:center;border-left:1px solid var(--hex-grid);position:relative;transition:all 0.2s}
+        .mobile-menu-toggle{display:none;background:transparent;border:none;font-size:1.5rem;color:var(--hex-black);cursor:pointer;padding:0 1.5rem;min-width:60px;outline:none}
+        .container{max-width:1400px;margin:0 auto;padding:0 20px;position:relative;z-index:2;width:100%}
+        .section-title{font-size:clamp(2rem,5vw,3rem);font-weight:700;text-transform:uppercase;text-align:center;padding-top:4rem;letter-spacing:-1px;margin-bottom:0.5rem}
+        .cookie-banner{position:fixed;bottom:0;left:0;right:0;background:var(--hex-black);color:var(--hex-white);z-index:9999;border-top:4px solid;border-image:var(--gradient-blue) 1;transform:translateY(100%);transition:transform 0.3s ease}.cookie-banner.visible{transform:translateY(0)}
+        .fade-in{opacity:0;transform:translateY(20px);animation:appear 0.5s ease forwards}@keyframes appear{to{opacity:1;transform:translateY(0)}}
+        .page-header{padding:60px 0 0;background:linear-gradient(90deg,var(--hex-grid) 1px,transparent 1px) 0 0,linear-gradient(180deg,var(--hex-grid) 1px,transparent 1px) 0 0;background-size:40px 40px;background-color:var(--hex-concrete);position:relative;overflow:hidden}
+        .page-header-content{max-width:1400px;margin:0 auto;padding:4rem 20px;position:relative;z-index:2}
+        .page-header-box{text-align:center;border:2px solid var(--hex-black);padding:3rem 4rem;background:var(--hex-white);box-shadow:15px 15px 0px var(--hex-black)}
+        .page-title{font-size:clamp(2rem,6vw,4rem);font-weight:700;line-height:0.9;text-transform:uppercase;letter-spacing:-2px;color:var(--hex-black);margin-bottom:1rem}.page-title span{background:var(--gradient-blue);background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent;display:inline-block}
+        .page-subtitle{font-family:'Courier New',Courier,monospace;font-size:clamp(0.9rem,2vw,1.1rem);text-transform:uppercase;background:var(--hex-black);color:var(--hex-white);display:inline-block;padding:5px 8px}
+        @media(max-width:768px){.navbar{background:transparent;border-bottom:none}.nav-logo{display:none}.nav-container{justify-content:flex-end}.mobile-menu-toggle{display:block;background:transparent;border:none;font-size:2rem;padding:1rem 1.5rem;color:var(--hex-black)}.nav-menu{display:none;flex-direction:column;position:absolute;top:70px;left:0;right:0;background:var(--hex-white);border-top:2px solid var(--hex-black);border-bottom:2px solid var(--hex-black);box-shadow:0 10px 20px rgba(0,0,0,0.1)}.nav-menu.active{display:flex}.nav-link{padding:1.5rem;border-left:none;border-bottom:1px solid #eee;min-height:48px}.nav-cta{padding:1.5rem;justify-content:center;border-left:none;min-height:48px}.container{padding:0 12px}.section-title{padding-top:2rem;margin-bottom:0}.page-header-box{padding:1.5rem 1rem;box-shadow:6px 6px 0 var(--hex-black)}.page-title{font-size:clamp(1.8rem,7vw,2.5rem);letter-spacing:-1px}.page-subtitle{font-size:clamp(0.65rem,2.5vw,0.85rem);word-break:break-word;padding:4px 6px}.page-header-content{padding:2.5rem 12px}}
+    </style>
+    <!-- Deferred stylesheets (non-render-blocking) -->
+    <link rel="stylesheet" href="/css/core.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/core.css"></noscript>
+    <link rel="stylesheet" href="/css/icons.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/icons.css"></noscript>
     <style>
         .page-header::before {
             content: "FIG. 09 — LEGAL";

--- a/reviews.html
+++ b/reviews.html
@@ -48,6 +48,8 @@
 
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin>
 
     <!-- Breadcrumb Schema -->
     <script type="application/ld+json">
@@ -152,8 +154,37 @@
     }
     </script>
 
-    <link rel="stylesheet" href="/css/core.css">
-    <link rel="stylesheet" href="/css/icons.css">
+    <!-- Critical CSS inlined for fast first paint -->
+    <style>
+        :root{--hex-accent:#0033FF;--gradient-blue:linear-gradient(135deg,#0033FF 0%,#00C6FF 100%);--hex-black:#111111;--hex-concrete:#F2F2F2;--hex-white:#FFFFFF;--hex-grid:#DCDCDC;--hazard-stripe:repeating-linear-gradient(135deg,#111111,#111111 10px,#ffffff 10px,#ffffff 20px);--font-main:'Helvetica Neue',Helvetica,Arial,sans-serif;--border-width:1px;--safe-area-bottom:env(safe-area-inset-bottom)}
+        html{scroll-behavior:smooth}*{margin:0;padding:0;box-sizing:border-box}
+        body{font-family:var(--font-main);background-color:var(--hex-concrete);color:var(--hex-black);line-height:1.4;overflow-x:hidden;font-weight:400;padding-bottom:calc(60px + var(--safe-area-bottom))}
+        .skip-link{position:absolute;top:-40px;left:0;background:var(--hex-black);color:var(--hex-white);padding:8px 16px;z-index:10000;transition:top 0.3s;text-decoration:none;font-weight:500;text-transform:uppercase;font-size:0.9rem}.skip-link:focus{top:0}
+        :focus-visible{outline:3px solid var(--hex-accent);outline-offset:2px}*{-webkit-tap-highlight-color:transparent}
+        .navbar{position:fixed;top:0;left:0;right:0;background:var(--hex-white);z-index:1000;border-bottom:2px solid var(--hex-black);padding:0}
+        .nav-container{max-width:100%;display:flex;justify-content:space-between;align-items:stretch;height:60px}
+        .nav-logo{font-size:1.5rem;font-weight:700;color:var(--hex-white);text-decoration:none;text-transform:uppercase;letter-spacing:-1px;padding:0 1.5rem;display:flex;align-items:center;background:var(--gradient-blue);border-right:2px solid var(--hex-black);position:relative}.nav-logo::after{content:"\2122";font-size:0.4em;position:relative;top:-0.6em;margin-left:2px;line-height:0;vertical-align:baseline}
+        .nav-cta{background:var(--hex-black);color:var(--hex-white);padding:0 2rem;text-decoration:none;font-weight:500;text-transform:uppercase;display:flex;align-items:center;gap:10px;font-size:0.8rem;border-left:2px solid var(--hex-black)}.nav-cta::before,.nav-cta::after{content:none}
+        .nav-menu{display:flex;list-style:none;gap:0;align-items:stretch;flex-grow:1;justify-content:flex-end}
+        .nav-menu li{display:flex;align-items:stretch}
+        .nav-link{text-decoration:none;color:var(--hex-black);font-weight:500;text-transform:uppercase;font-size:0.9rem;padding:0 2rem;display:flex;align-items:center;border-left:1px solid var(--hex-grid);position:relative;transition:all 0.2s}
+        .mobile-menu-toggle{display:none;background:transparent;border:none;font-size:1.5rem;color:var(--hex-black);cursor:pointer;padding:0 1.5rem;min-width:60px;outline:none}
+        .container{max-width:1400px;margin:0 auto;padding:0 20px;position:relative;z-index:2;width:100%}
+        .section-title{font-size:clamp(2rem,5vw,3rem);font-weight:700;text-transform:uppercase;text-align:center;padding-top:4rem;letter-spacing:-1px;margin-bottom:0.5rem}
+        .cookie-banner{position:fixed;bottom:0;left:0;right:0;background:var(--hex-black);color:var(--hex-white);z-index:9999;border-top:4px solid;border-image:var(--gradient-blue) 1;transform:translateY(100%);transition:transform 0.3s ease}.cookie-banner.visible{transform:translateY(0)}
+        .fade-in{opacity:0;transform:translateY(20px);animation:appear 0.5s ease forwards}@keyframes appear{to{opacity:1;transform:translateY(0)}}
+        .page-header{padding:60px 0 0;background:linear-gradient(90deg,var(--hex-grid) 1px,transparent 1px) 0 0,linear-gradient(180deg,var(--hex-grid) 1px,transparent 1px) 0 0;background-size:40px 40px;background-color:var(--hex-concrete);position:relative;overflow:hidden}
+        .page-header-content{max-width:1400px;margin:0 auto;padding:4rem 20px;position:relative;z-index:2}
+        .page-header-box{text-align:center;border:2px solid var(--hex-black);padding:3rem 4rem;background:var(--hex-white);box-shadow:15px 15px 0px var(--hex-black)}
+        .page-title{font-size:clamp(2rem,6vw,4rem);font-weight:700;line-height:0.9;text-transform:uppercase;letter-spacing:-2px;color:var(--hex-black);margin-bottom:1rem}.page-title span{background:var(--gradient-blue);background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent;display:inline-block}
+        .page-subtitle{font-family:'Courier New',Courier,monospace;font-size:clamp(0.9rem,2vw,1.1rem);text-transform:uppercase;background:var(--hex-black);color:var(--hex-white);display:inline-block;padding:5px 8px}
+        @media(max-width:768px){.navbar{background:transparent;border-bottom:none}.nav-logo{display:none}.nav-container{justify-content:flex-end}.mobile-menu-toggle{display:block;background:transparent;border:none;font-size:2rem;padding:1rem 1.5rem;color:var(--hex-black)}.nav-menu{display:none;flex-direction:column;position:absolute;top:70px;left:0;right:0;background:var(--hex-white);border-top:2px solid var(--hex-black);border-bottom:2px solid var(--hex-black);box-shadow:0 10px 20px rgba(0,0,0,0.1)}.nav-menu.active{display:flex}.nav-link{padding:1.5rem;border-left:none;border-bottom:1px solid #eee;min-height:48px}.nav-cta{padding:1.5rem;justify-content:center;border-left:none;min-height:48px}.container{padding:0 12px}.section-title{padding-top:2rem;margin-bottom:0}.page-header-box{padding:1.5rem 1rem;box-shadow:6px 6px 0 var(--hex-black)}.page-title{font-size:clamp(1.8rem,7vw,2.5rem);letter-spacing:-1px}.page-subtitle{font-size:clamp(0.65rem,2.5vw,0.85rem);word-break:break-word;padding:4px 6px}.page-header-content{padding:2.5rem 12px}}
+    </style>
+    <!-- Deferred stylesheets (non-render-blocking) -->
+    <link rel="stylesheet" href="/css/core.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/core.css"></noscript>
+    <link rel="stylesheet" href="/css/icons.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/icons.css"></noscript>
     <style>
         .page-header::before {
             content: "FIG. 06 — CLIENT FEEDBACK";

--- a/services.html
+++ b/services.html
@@ -54,6 +54,8 @@
     <!-- Performance: DNS Prefetch and Preconnect -->
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin>
 
 
     <!-- Breadcrumb Schema -->
@@ -134,8 +136,37 @@
     }
     </script>
 
-    <link rel="stylesheet" href="/css/core.css">
-    <link rel="stylesheet" href="/css/icons.css">
+    <!-- Critical CSS inlined for fast first paint -->
+    <style>
+        :root{--hex-accent:#0033FF;--gradient-blue:linear-gradient(135deg,#0033FF 0%,#00C6FF 100%);--hex-black:#111111;--hex-concrete:#F2F2F2;--hex-white:#FFFFFF;--hex-grid:#DCDCDC;--hazard-stripe:repeating-linear-gradient(135deg,#111111,#111111 10px,#ffffff 10px,#ffffff 20px);--font-main:'Helvetica Neue',Helvetica,Arial,sans-serif;--border-width:1px;--safe-area-bottom:env(safe-area-inset-bottom)}
+        html{scroll-behavior:smooth}*{margin:0;padding:0;box-sizing:border-box}
+        body{font-family:var(--font-main);background-color:var(--hex-concrete);color:var(--hex-black);line-height:1.4;overflow-x:hidden;font-weight:400;padding-bottom:calc(60px + var(--safe-area-bottom))}
+        .skip-link{position:absolute;top:-40px;left:0;background:var(--hex-black);color:var(--hex-white);padding:8px 16px;z-index:10000;transition:top 0.3s;text-decoration:none;font-weight:500;text-transform:uppercase;font-size:0.9rem}.skip-link:focus{top:0}
+        :focus-visible{outline:3px solid var(--hex-accent);outline-offset:2px}*{-webkit-tap-highlight-color:transparent}
+        .navbar{position:fixed;top:0;left:0;right:0;background:var(--hex-white);z-index:1000;border-bottom:2px solid var(--hex-black);padding:0}
+        .nav-container{max-width:100%;display:flex;justify-content:space-between;align-items:stretch;height:60px}
+        .nav-logo{font-size:1.5rem;font-weight:700;color:var(--hex-white);text-decoration:none;text-transform:uppercase;letter-spacing:-1px;padding:0 1.5rem;display:flex;align-items:center;background:var(--gradient-blue);border-right:2px solid var(--hex-black);position:relative}.nav-logo::after{content:"\2122";font-size:0.4em;position:relative;top:-0.6em;margin-left:2px;line-height:0;vertical-align:baseline}
+        .nav-cta{background:var(--hex-black);color:var(--hex-white);padding:0 2rem;text-decoration:none;font-weight:500;text-transform:uppercase;display:flex;align-items:center;gap:10px;font-size:0.8rem;border-left:2px solid var(--hex-black)}.nav-cta::before,.nav-cta::after{content:none}
+        .nav-menu{display:flex;list-style:none;gap:0;align-items:stretch;flex-grow:1;justify-content:flex-end}
+        .nav-menu li{display:flex;align-items:stretch}
+        .nav-link{text-decoration:none;color:var(--hex-black);font-weight:500;text-transform:uppercase;font-size:0.9rem;padding:0 2rem;display:flex;align-items:center;border-left:1px solid var(--hex-grid);position:relative;transition:all 0.2s}
+        .mobile-menu-toggle{display:none;background:transparent;border:none;font-size:1.5rem;color:var(--hex-black);cursor:pointer;padding:0 1.5rem;min-width:60px;outline:none}
+        .container{max-width:1400px;margin:0 auto;padding:0 20px;position:relative;z-index:2;width:100%}
+        .section-title{font-size:clamp(2rem,5vw,3rem);font-weight:700;text-transform:uppercase;text-align:center;padding-top:4rem;letter-spacing:-1px;margin-bottom:0.5rem}
+        .cookie-banner{position:fixed;bottom:0;left:0;right:0;background:var(--hex-black);color:var(--hex-white);z-index:9999;border-top:4px solid;border-image:var(--gradient-blue) 1;transform:translateY(100%);transition:transform 0.3s ease}.cookie-banner.visible{transform:translateY(0)}
+        .fade-in{opacity:0;transform:translateY(20px);animation:appear 0.5s ease forwards}@keyframes appear{to{opacity:1;transform:translateY(0)}}
+        .page-header{padding:60px 0 0;background:linear-gradient(90deg,var(--hex-grid) 1px,transparent 1px) 0 0,linear-gradient(180deg,var(--hex-grid) 1px,transparent 1px) 0 0;background-size:40px 40px;background-color:var(--hex-concrete);position:relative;overflow:hidden}
+        .page-header-content{max-width:1400px;margin:0 auto;padding:4rem 20px;position:relative;z-index:2}
+        .page-header-box{text-align:center;border:2px solid var(--hex-black);padding:3rem 4rem;background:var(--hex-white);box-shadow:15px 15px 0px var(--hex-black)}
+        .page-title{font-size:clamp(2rem,6vw,4rem);font-weight:700;line-height:0.9;text-transform:uppercase;letter-spacing:-2px;color:var(--hex-black);margin-bottom:1rem}.page-title span{background:var(--gradient-blue);background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent;display:inline-block}
+        .page-subtitle{font-family:'Courier New',Courier,monospace;font-size:clamp(0.9rem,2vw,1.1rem);text-transform:uppercase;background:var(--hex-black);color:var(--hex-white);display:inline-block;padding:5px 8px}
+        @media(max-width:768px){.navbar{background:transparent;border-bottom:none}.nav-logo{display:none}.nav-container{justify-content:flex-end}.mobile-menu-toggle{display:block;background:transparent;border:none;font-size:2rem;padding:1rem 1.5rem;color:var(--hex-black)}.nav-menu{display:none;flex-direction:column;position:absolute;top:70px;left:0;right:0;background:var(--hex-white);border-top:2px solid var(--hex-black);border-bottom:2px solid var(--hex-black);box-shadow:0 10px 20px rgba(0,0,0,0.1)}.nav-menu.active{display:flex}.nav-link{padding:1.5rem;border-left:none;border-bottom:1px solid #eee;min-height:48px}.nav-cta{padding:1.5rem;justify-content:center;border-left:none;min-height:48px}.container{padding:0 12px}.section-title{padding-top:2rem;margin-bottom:0}.page-header-box{padding:1.5rem 1rem;box-shadow:6px 6px 0 var(--hex-black)}.page-title{font-size:clamp(1.8rem,7vw,2.5rem);letter-spacing:-1px}.page-subtitle{font-size:clamp(0.65rem,2.5vw,0.85rem);word-break:break-word;padding:4px 6px}.page-header-content{padding:2.5rem 12px}}
+    </style>
+    <!-- Deferred stylesheets (non-render-blocking) -->
+    <link rel="stylesheet" href="/css/core.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/core.css"></noscript>
+    <link rel="stylesheet" href="/css/icons.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/icons.css"></noscript>
     <style>
         .page-header::before {
             content: "FIG. 03 — SERVICE CATALOG";

--- a/tablet-repair.html
+++ b/tablet-repair.html
@@ -53,6 +53,8 @@
     <!-- Performance: DNS Prefetch and Preconnect -->
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/webfonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin>
 
 
     <!-- Breadcrumb Schema -->
@@ -296,8 +298,37 @@
     }
     </script>
 
-    <link rel="stylesheet" href="/css/core.css">
-    <link rel="stylesheet" href="/css/icons.css">
+    <!-- Critical CSS inlined for fast first paint -->
+    <style>
+        :root{--hex-accent:#0033FF;--gradient-blue:linear-gradient(135deg,#0033FF 0%,#00C6FF 100%);--hex-black:#111111;--hex-concrete:#F2F2F2;--hex-white:#FFFFFF;--hex-grid:#DCDCDC;--hazard-stripe:repeating-linear-gradient(135deg,#111111,#111111 10px,#ffffff 10px,#ffffff 20px);--font-main:'Helvetica Neue',Helvetica,Arial,sans-serif;--border-width:1px;--safe-area-bottom:env(safe-area-inset-bottom)}
+        html{scroll-behavior:smooth}*{margin:0;padding:0;box-sizing:border-box}
+        body{font-family:var(--font-main);background-color:var(--hex-concrete);color:var(--hex-black);line-height:1.4;overflow-x:hidden;font-weight:400;padding-bottom:calc(60px + var(--safe-area-bottom))}
+        .skip-link{position:absolute;top:-40px;left:0;background:var(--hex-black);color:var(--hex-white);padding:8px 16px;z-index:10000;transition:top 0.3s;text-decoration:none;font-weight:500;text-transform:uppercase;font-size:0.9rem}.skip-link:focus{top:0}
+        :focus-visible{outline:3px solid var(--hex-accent);outline-offset:2px}*{-webkit-tap-highlight-color:transparent}
+        .navbar{position:fixed;top:0;left:0;right:0;background:var(--hex-white);z-index:1000;border-bottom:2px solid var(--hex-black);padding:0}
+        .nav-container{max-width:100%;display:flex;justify-content:space-between;align-items:stretch;height:60px}
+        .nav-logo{font-size:1.5rem;font-weight:700;color:var(--hex-white);text-decoration:none;text-transform:uppercase;letter-spacing:-1px;padding:0 1.5rem;display:flex;align-items:center;background:var(--gradient-blue);border-right:2px solid var(--hex-black);position:relative}.nav-logo::after{content:"\2122";font-size:0.4em;position:relative;top:-0.6em;margin-left:2px;line-height:0;vertical-align:baseline}
+        .nav-cta{background:var(--hex-black);color:var(--hex-white);padding:0 2rem;text-decoration:none;font-weight:500;text-transform:uppercase;display:flex;align-items:center;gap:10px;font-size:0.8rem;border-left:2px solid var(--hex-black)}.nav-cta::before,.nav-cta::after{content:none}
+        .nav-menu{display:flex;list-style:none;gap:0;align-items:stretch;flex-grow:1;justify-content:flex-end}
+        .nav-menu li{display:flex;align-items:stretch}
+        .nav-link{text-decoration:none;color:var(--hex-black);font-weight:500;text-transform:uppercase;font-size:0.9rem;padding:0 2rem;display:flex;align-items:center;border-left:1px solid var(--hex-grid);position:relative;transition:all 0.2s}
+        .mobile-menu-toggle{display:none;background:transparent;border:none;font-size:1.5rem;color:var(--hex-black);cursor:pointer;padding:0 1.5rem;min-width:60px;outline:none}
+        .container{max-width:1400px;margin:0 auto;padding:0 20px;position:relative;z-index:2;width:100%}
+        .section-title{font-size:clamp(2rem,5vw,3rem);font-weight:700;text-transform:uppercase;text-align:center;padding-top:4rem;letter-spacing:-1px;margin-bottom:0.5rem}
+        .cookie-banner{position:fixed;bottom:0;left:0;right:0;background:var(--hex-black);color:var(--hex-white);z-index:9999;border-top:4px solid;border-image:var(--gradient-blue) 1;transform:translateY(100%);transition:transform 0.3s ease}.cookie-banner.visible{transform:translateY(0)}
+        .fade-in{opacity:0;transform:translateY(20px);animation:appear 0.5s ease forwards}@keyframes appear{to{opacity:1;transform:translateY(0)}}
+        .page-header{padding:60px 0 0;background:linear-gradient(90deg,var(--hex-grid) 1px,transparent 1px) 0 0,linear-gradient(180deg,var(--hex-grid) 1px,transparent 1px) 0 0;background-size:40px 40px;background-color:var(--hex-concrete);position:relative;overflow:hidden}
+        .page-header-content{max-width:1400px;margin:0 auto;padding:4rem 20px;position:relative;z-index:2}
+        .page-header-box{text-align:center;border:2px solid var(--hex-black);padding:3rem 4rem;background:var(--hex-white);box-shadow:15px 15px 0px var(--hex-black)}
+        .page-title{font-size:clamp(2rem,6vw,4rem);font-weight:700;line-height:0.9;text-transform:uppercase;letter-spacing:-2px;color:var(--hex-black);margin-bottom:1rem}.page-title span{background:var(--gradient-blue);background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent;display:inline-block}
+        .page-subtitle{font-family:'Courier New',Courier,monospace;font-size:clamp(0.9rem,2vw,1.1rem);text-transform:uppercase;background:var(--hex-black);color:var(--hex-white);display:inline-block;padding:5px 8px}
+        @media(max-width:768px){.navbar{background:transparent;border-bottom:none}.nav-logo{display:none}.nav-container{justify-content:flex-end}.mobile-menu-toggle{display:block;background:transparent;border:none;font-size:2rem;padding:1rem 1.5rem;color:var(--hex-black)}.nav-menu{display:none;flex-direction:column;position:absolute;top:70px;left:0;right:0;background:var(--hex-white);border-top:2px solid var(--hex-black);border-bottom:2px solid var(--hex-black);box-shadow:0 10px 20px rgba(0,0,0,0.1)}.nav-menu.active{display:flex}.nav-link{padding:1.5rem;border-left:none;border-bottom:1px solid #eee;min-height:48px}.nav-cta{padding:1.5rem;justify-content:center;border-left:none;min-height:48px}.container{padding:0 12px}.section-title{padding-top:2rem;margin-bottom:0}.page-header-box{padding:1.5rem 1rem;box-shadow:6px 6px 0 var(--hex-black)}.page-title{font-size:clamp(1.8rem,7vw,2.5rem);letter-spacing:-1px}.page-subtitle{font-size:clamp(0.65rem,2.5vw,0.85rem);word-break:break-word;padding:4px 6px}.page-header-content{padding:2.5rem 12px}}
+    </style>
+    <!-- Deferred stylesheets (non-render-blocking) -->
+    <link rel="stylesheet" href="/css/core.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/core.css"></noscript>
+    <link rel="stylesheet" href="/css/icons.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/icons.css"></noscript>
     <style>
         html { overflow-x: hidden; }
 


### PR DESCRIPTION
- Inline critical above-the-fold CSS in all HTML pages
- Defer core.css and icons.css with media="print" onload trick + noscript fallback
- Preload Font Awesome woff2 files to break critical request chain
- Fix forced reflow in cookies.js: replace offsetHeight with double rAF
- Fix forced reflow in core.js: use matchMedia instead of innerWidth

https://claude.ai/code/session_017pwW1e3tvXUULPBdjghpcu