### PR TITLE
Defer particle animation until after LCP to reduce forced reflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -1046,71 +1046,50 @@
     </div>
 
 
+    <style>
+        @keyframes float-up {
+            0% { transform: translateY(0) rotate(0deg); opacity: 0.7; }
+            100% { transform: translateY(-100vh) rotate(90deg); opacity: 0; }
+        }
+    </style>
     <script>
-        // Floating particles
-        let particleInterval = null;
+        // Defer particles until after LCP to avoid forced reflow during load
+        (function() {
+            var particleInterval = null;
+            var heroSection = null;
 
-        function createFloatingElement(targetSection) {
-            if (!targetSection) return;
-
-            const element = document.createElement('div');
-            const size = Math.random() * 2 + 3;
-
-            element.style.cssText = `
-                position: absolute;
-                width: ${size}px;
-                height: ${size}px;
-                background: #0033FF;
-                pointer-events: none;
-                animation: float-up 8s linear infinite;
-                left: ${Math.random() * 100}%;
-                top: 100%;
-                z-index: 1;
-                opacity: 0.7;
-            `;
-
-            targetSection.appendChild(element);
-
-            setTimeout(() => {
-                if (element.parentNode) {
-                    element.remove();
-                }
-            }, 8000);
-        }
-
-        const floatingStyle = document.createElement('style');
-        floatingStyle.textContent = `
-            @keyframes float-up {
-                0% { transform: translateY(0px) rotate(0deg); opacity: 0.7; }
-                100% { transform: translateY(-100vh) rotate(90deg); opacity: 0; }
+            function createFloatingElement() {
+                if (!heroSection) return;
+                var el = document.createElement('div');
+                var size = Math.random() * 2 + 3;
+                el.style.cssText = 'position:absolute;width:' + size + 'px;height:' + size + 'px;background:#0033FF;pointer-events:none;animation:float-up 8s linear infinite;left:' + (Math.random() * 100) + '%;top:100%;z-index:1;opacity:0.7;will-change:transform,opacity';
+                heroSection.appendChild(el);
+                setTimeout(function() { if (el.parentNode) el.remove(); }, 8000);
             }
-        `;
-        document.head.appendChild(floatingStyle);
 
-        const heroSection = document.querySelector('.hero');
-
-        function startParticles() {
-            if (heroSection && !particleInterval) {
-                particleInterval = setInterval(() => createFloatingElement(heroSection), 100);
+            function start() {
+                if (!particleInterval) particleInterval = setInterval(createFloatingElement, 150);
             }
-        }
-
-        function stopParticles() {
-            if (particleInterval) {
-                clearInterval(particleInterval);
-                particleInterval = null;
+            function stop() {
+                if (particleInterval) { clearInterval(particleInterval); particleInterval = null; }
             }
-        }
 
-        startParticles();
+            // Wait until after paint to avoid reflow during LCP
+            function init() {
+                heroSection = document.querySelector('.hero');
+                if (!heroSection) return;
+                start();
+                document.addEventListener('visibilitychange', function() {
+                    document.hidden ? stop() : start();
+                });
+            }
 
-        document.addEventListener('visibilitychange', () => {
-            if (document.hidden) {
-                stopParticles();
+            if ('requestIdleCallback' in window) {
+                requestIdleCallback(init, { timeout: 3000 });
             } else {
-                startParticles();
+                setTimeout(init, 2000);
             }
-        });
+        })();
     </script>
     <script src="/js/core.js" defer></script>
     <script src="/js/cookies.js" defer></script>


### PR DESCRIPTION
- Use requestIdleCallback to delay particle init past LCP measurement
- Move float-up keyframe to static <style> tag instead of JS-created element
- Increase particle interval from 100ms to 150ms to reduce DOM churn
- Add will-change hint for smoother GPU-composited animations

https://claude.ai/code/session_017pwW1e3tvXUULPBdjghpcu