### PR TITLE
Add security headers and CSP meta tags for Mozilla Observatory

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,6 +6,7 @@
     <meta name="theme-color" content="#0033FF">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'">
     <title>404 — Page Not Found | OnlineFix</title>
     <meta name="robots" content="noindex, follow">
     <link rel="icon" type="image/png" sizes="512x512" href="/favicon-512x512.png">

--- a/_headers
+++ b/_headers
@@ -1,11 +1,16 @@
-# HTTP Response Headers
+# HTTP Security Headers
 # Works with: Cloudflare Pages, Netlify
-# For GitHub Pages: configure these via Cloudflare proxy or server config
+# For GitHub Pages: configure via Cloudflare proxy Transform Rules
 
 /*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=()
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Resource-Policy: same-origin
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://www.recaptcha.net https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://*.googleapis.com https://*.firebaseio.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com; font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; img-src 'self' data: https://firebasestorage.googleapis.com https://*.firebasestorage.app https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://*.firebasestorage.app https://www.google-analytics.com https://www.googletagmanager.com https://api.emailjs.com; frame-src 'self' https://www.google.com https://www.recaptcha.net; object-src 'none'; base-uri 'self'; form-action 'self'
 
 /css/*
   Cache-Control: public, max-age=31536000, immutable

--- a/about.html
+++ b/about.html
@@ -8,6 +8,7 @@
 
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'">
 
     <title>About OnlineFix | Repair Technician Guildford</title>
     <meta name="description"

--- a/console-repair.html
+++ b/console-repair.html
@@ -9,6 +9,7 @@
     <!-- Security & Privacy -->
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'">
 
     <!-- SEO Meta Tags - CONSOLE REPAIR LANDING PAGE -->
     <title>Console Repair Guildford | PS5, Xbox &amp; Switch Fix | OnlineFix</title>

--- a/contact.html
+++ b/contact.html
@@ -8,6 +8,7 @@
 
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'">
 
     <title>Contact OnlineFix | Guildford Repair Shop</title>
     <meta name="description"

--- a/data-recovery.html
+++ b/data-recovery.html
@@ -8,6 +8,7 @@
     <!-- Security & Privacy -->
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'">
 
     <!-- SEO Meta Tags - DATA RECOVERY LANDING PAGE -->
     <title>Data Recovery Guildford | OnlineFix</title>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <!-- Security & Privacy -->
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'">
 
     <!-- SEO Meta Tags - OPTIMIZED FOR GBP & LOCAL SEARCH -->
     <title>OnlineFix Guildford | Phone, Laptop, PC &amp; Console Repair Surrey</title>

--- a/iphone-repair.html
+++ b/iphone-repair.html
@@ -8,6 +8,7 @@
     <!-- Security & Privacy -->
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'">
 
     <!-- SEO Meta Tags - IPHONE REPAIR LANDING PAGE -->
     <title>Phone &amp; iPhone Repair Guildford | Same-Day Fix | OnlineFix</title>

--- a/macbook-repair.html
+++ b/macbook-repair.html
@@ -8,6 +8,7 @@
     <!-- Security & Privacy -->
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'">
 
     <!-- SEO Meta Tags - MACBOOK REPAIR LANDING PAGE -->
     <title>MacBook Repair Guildford | Same-Day | OnlineFix</title>

--- a/pc-repair.html
+++ b/pc-repair.html
@@ -9,6 +9,7 @@
     <!-- Security & Privacy -->
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'">
 
     <!-- SEO Meta Tags - PC REPAIR LANDING PAGE -->
     <title>Laptop, PC &amp; Computer Repair Guildford | Same-Day | OnlineFix</title>

--- a/privacy.html
+++ b/privacy.html
@@ -8,6 +8,7 @@
 
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'">
 
     <title>Privacy & Cookie Policy | OnlineFix Guildford</title>
     <meta name="description"

--- a/reviews.html
+++ b/reviews.html
@@ -8,6 +8,7 @@
 
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'">
 
     <title>Customer Reviews | OnlineFix Guildford</title>
     <meta name="description"

--- a/services.html
+++ b/services.html
@@ -9,6 +9,7 @@
     <!-- Security & Privacy -->
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'">
 
     <!-- SEO Meta Tags -->
     <title>Electronics Repair Services Guildford | OnlineFix</title>

--- a/tablet-repair.html
+++ b/tablet-repair.html
@@ -8,6 +8,7 @@
     <!-- Security & Privacy -->
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'">
 
     <!-- SEO Meta Tags - TABLET REPAIR LANDING PAGE -->
     <title>iPad &amp; Tablet Repair Guildford | OnlineFix</title>


### PR DESCRIPTION
- Update _headers with full security header set (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Permissions-Policy, COOP, CORP) ready for Cloudflare Pages/proxy deployment
- Add Content-Security-Policy meta tag to all 13 public HTML pages for immediate browser-enforced protection
- CSP allows self-hosted resources + cdnjs.cloudflare.com for Font Awesome

https://claude.ai/code/session_017pwW1e3tvXUULPBdjghpcu