### PR TITLE
Add Manage Cookies footer link and ReCAPTCHA privacy disclosure

### DIFF
--- a/about.html
+++ b/about.html
@@ -742,6 +742,7 @@
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>
                         <li><a href="privacy.html">Privacy &amp; Cookies</a></li>
+                        <li><a href="#" onclick="cookieManage();return false;">Manage Cookies</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">

--- a/console-repair.html
+++ b/console-repair.html
@@ -1679,6 +1679,7 @@
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>
                         <li><a href="privacy.html">Privacy &amp; Cookies</a></li>
+                        <li><a href="#" onclick="cookieManage();return false;">Manage Cookies</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">

--- a/contact.html
+++ b/contact.html
@@ -830,6 +830,7 @@
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>
                         <li><a href="privacy.html">Privacy &amp; Cookies</a></li>
+                        <li><a href="#" onclick="cookieManage();return false;">Manage Cookies</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">

--- a/data-recovery.html
+++ b/data-recovery.html
@@ -926,6 +926,7 @@
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>
                         <li><a href="privacy.html">Privacy &amp; Cookies</a></li>
+                        <li><a href="#" onclick="cookieManage();return false;">Manage Cookies</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">

--- a/index.html
+++ b/index.html
@@ -1014,6 +1014,7 @@
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>
                         <li><a href="privacy.html">Privacy & Cookies</a></li>
+                        <li><a href="#" onclick="cookieManage();return false;">Manage Cookies</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">

--- a/iphone-repair.html
+++ b/iphone-repair.html
@@ -1015,6 +1015,7 @@
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>
                         <li><a href="privacy.html">Privacy &amp; Cookies</a></li>
+                        <li><a href="#" onclick="cookieManage();return false;">Manage Cookies</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">

--- a/js/cookies.js
+++ b/js/cookies.js
@@ -86,6 +86,9 @@
     // Expose functions globally for button onclick handlers
     window.cookieConsentAccept = acceptAll;
     window.cookieConsentReject = rejectNonEssential;
+    window.cookieManage = function () {
+        showBanner();
+    };
 
     // Initialise on DOM ready
     function init() {

--- a/macbook-repair.html
+++ b/macbook-repair.html
@@ -928,6 +928,7 @@
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>
                         <li><a href="privacy.html">Privacy &amp; Cookies</a></li>
+                        <li><a href="#" onclick="cookieManage();return false;">Manage Cookies</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">

--- a/pc-repair.html
+++ b/pc-repair.html
@@ -1653,6 +1653,7 @@
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>
                         <li><a href="privacy.html">Privacy &amp; Cookies</a></li>
+                        <li><a href="#" onclick="cookieManage();return false;">Manage Cookies</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">

--- a/playstation-repair.html
+++ b/playstation-repair.html
@@ -1283,6 +1283,7 @@
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>
                         <li><a href="privacy.html">Privacy &amp; Cookies</a></li>
+                        <li><a href="#" onclick="cookieManage();return false;">Manage Cookies</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">

--- a/privacy.html
+++ b/privacy.html
@@ -343,7 +343,7 @@
                                 </tr>
                             </tbody>
                         </table>
-                        <p><strong>Analytics cookies are only set after you give consent</strong> via the cookie banner. You can change your preference at any time by clearing your browser's local storage for this site.</p>
+                        <p><strong>Analytics cookies are only set after you give consent</strong> via the cookie banner. You can change your preference at any time by clicking the "Manage Cookies" link in the footer of any page.</p>
                     </div>
 
                     <div class="privacy-block">
@@ -351,7 +351,8 @@
                         <ul>
                             <li><strong>Google Analytics:</strong> We use Google Analytics 4 to understand how visitors use our site. IP addresses are anonymised. Data is processed by Google LLC. <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Google's Privacy Policy</a></li>
                             <li><strong>Firebase:</strong> Used for our internal repair tracking system. Data is processed by Google LLC</li>
-                            <li><strong>Cloudflare CDN:</strong> Delivers Font Awesome icons. May set technical cookies for performance</li>
+                            <li><strong>Google reCAPTCHA:</strong> Used on our repair booking and tracking forms to prevent spam and abuse. reCAPTCHA collects hardware and software information (such as device data, IP address, and browser interactions) and sends it to Google for analysis. Data is processed by Google LLC under their <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a> and <a href="https://policies.google.com/terms" target="_blank" rel="noopener noreferrer">Terms of Service</a></li>
+                            <li><strong>Cloudflare:</strong> Provides CDN, security, and performance services. May set strictly necessary cookies (such as <code>__cf_bm</code>) for bot protection. <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener noreferrer">Cloudflare's Privacy Policy</a></li>
                         </ul>
                     </div>
 

--- a/reviews.html
+++ b/reviews.html
@@ -914,6 +914,7 @@
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>
                         <li><a href="privacy.html">Privacy &amp; Cookies</a></li>
+                        <li><a href="#" onclick="cookieManage();return false;">Manage Cookies</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">

--- a/services.html
+++ b/services.html
@@ -751,6 +751,7 @@
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>
                         <li><a href="privacy.html">Privacy &amp; Cookies</a></li>
+                        <li><a href="#" onclick="cookieManage();return false;">Manage Cookies</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">

--- a/tablet-repair.html
+++ b/tablet-repair.html
@@ -926,6 +926,7 @@
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>
                         <li><a href="privacy.html">Privacy &amp; Cookies</a></li>
+                        <li><a href="#" onclick="cookieManage();return false;">Manage Cookies</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">

--- a/xbox-repair.html
+++ b/xbox-repair.html
@@ -1285,6 +1285,7 @@
                         <li><a href="reviews.html">Reviews</a></li>
                         <li><a href="contact.html">Contact</a></li>
                         <li><a href="privacy.html">Privacy &amp; Cookies</a></li>
+                        <li><a href="#" onclick="cookieManage();return false;">Manage Cookies</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">


### PR DESCRIPTION
- Added "Manage Cookies" link to footer on all 13 public pages, allowing users to re-open the cookie consent banner and withdraw or change their consent (GDPR requirement).
- Added cookieManage() function to cookies.js.
- Added Google reCAPTCHA and updated Cloudflare disclosure in privacy policy third-party services section.
- Updated consent withdrawal instructions to reference the new Manage Cookies link instead of manual localStorage clearing.

https://claude.ai/code/session_017pwW1e3tvXUULPBdjghpcu