### PR TITLE
Add PWA install button + bump sync workflow to Node 22

### DIFF
--- a/.github/workflows/sync-gbp-reviews.yml
+++ b/.github/workflows/sync-gbp-reviews.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Run sync script
         env:

--- a/about.html
+++ b/about.html
@@ -734,6 +734,10 @@
                             style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok"
                                 aria-hidden="true"></i></a>
                     </div>
+                    <button type="button" class="install-app-btn" data-install-app hidden aria-hidden="true">
+                        <i class="fas fa-download" aria-hidden="true"></i>
+                        <span>Install App</span>
+                    </button>
                 </div>
                 <div class="footer-column">
                     <p class="footer-heading">LINKS</p>

--- a/console-repair.html
+++ b/console-repair.html
@@ -1678,6 +1678,10 @@
                             style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok"
                                 aria-hidden="true"></i></a>
                     </div>
+                    <button type="button" class="install-app-btn" data-install-app hidden aria-hidden="true">
+                        <i class="fas fa-download" aria-hidden="true"></i>
+                        <span>Install App</span>
+                    </button>
                 </div>
                 <div class="footer-column">
                     <p class="footer-heading">LINKS</p>

--- a/contact.html
+++ b/contact.html
@@ -822,6 +822,10 @@
                             style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok"
                                 aria-hidden="true"></i></a>
                     </div>
+                    <button type="button" class="install-app-btn" data-install-app hidden aria-hidden="true">
+                        <i class="fas fa-download" aria-hidden="true"></i>
+                        <span>Install App</span>
+                    </button>
                 </div>
                 <div class="footer-column">
                     <p class="footer-heading">LINKS</p>

--- a/css/core.css
+++ b/css/core.css
@@ -539,6 +539,30 @@ a[aria-label] > i[class*="fa-"]:only-child,
     text-decoration: underline;
 }
 
+/* PWA install button — only visible when the browser fires beforeinstallprompt.
+   Kept subtle: outline style, monospace, matches the footer aesthetic. */
+.install-app-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 1rem;
+    padding: 0.5rem 1rem;
+    background: transparent;
+    border: 1px solid #555;
+    color: #ccc;
+    font-family: monospace;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    cursor: pointer;
+    min-height: 44px;
+}
+
+.install-app-btn:hover,
+.install-app-btn:focus-visible {
+    color: var(--hex-white);
+    border-color: var(--hex-white);
+}
+
 .google-btn {
     border: 1px solid var(--hex-black);
     padding: 1rem 2rem;

--- a/data-recovery.html
+++ b/data-recovery.html
@@ -925,6 +925,10 @@
                         <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
                         <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
+                    <button type="button" class="install-app-btn" data-install-app hidden aria-hidden="true">
+                        <i class="fas fa-download" aria-hidden="true"></i>
+                        <span>Install App</span>
+                    </button>
                 </div>
                 <div class="footer-column">
                     <p class="footer-heading">LINKS</p>

--- a/index.html
+++ b/index.html
@@ -1006,6 +1006,10 @@
                             style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok"
                                 aria-hidden="true"></i></a>
                     </div>
+                    <button type="button" class="install-app-btn" data-install-app hidden aria-hidden="true">
+                        <i class="fas fa-download" aria-hidden="true"></i>
+                        <span>Install App</span>
+                    </button>
                 </div>
                 <div class="footer-column">
                     <p class="footer-heading">LINKS</p>

--- a/iphone-repair.html
+++ b/iphone-repair.html
@@ -1014,6 +1014,10 @@
                         <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
                         <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
+                    <button type="button" class="install-app-btn" data-install-app hidden aria-hidden="true">
+                        <i class="fas fa-download" aria-hidden="true"></i>
+                        <span>Install App</span>
+                    </button>
                 </div>
                 <div class="footer-column">
                     <p class="footer-heading">LINKS</p>

--- a/macbook-repair.html
+++ b/macbook-repair.html
@@ -927,6 +927,10 @@
                         <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
                         <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
+                    <button type="button" class="install-app-btn" data-install-app hidden aria-hidden="true">
+                        <i class="fas fa-download" aria-hidden="true"></i>
+                        <span>Install App</span>
+                    </button>
                 </div>
                 <div class="footer-column">
                     <p class="footer-heading">LINKS</p>

--- a/pc-repair.html
+++ b/pc-repair.html
@@ -1652,6 +1652,10 @@
                             style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok"
                                 aria-hidden="true"></i></a>
                     </div>
+                    <button type="button" class="install-app-btn" data-install-app hidden aria-hidden="true">
+                        <i class="fas fa-download" aria-hidden="true"></i>
+                        <span>Install App</span>
+                    </button>
                 </div>
                 <div class="footer-column">
                     <p class="footer-heading">LINKS</p>

--- a/playstation-repair.html
+++ b/playstation-repair.html
@@ -1275,6 +1275,10 @@
                             style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok"
                                 aria-hidden="true"></i></a>
                     </div>
+                    <button type="button" class="install-app-btn" data-install-app hidden aria-hidden="true">
+                        <i class="fas fa-download" aria-hidden="true"></i>
+                        <span>Install App</span>
+                    </button>
                 </div>
                 <div class="footer-column">
                     <p class="footer-heading">LINKS</p>

--- a/privacy.html
+++ b/privacy.html
@@ -423,6 +423,10 @@
                             style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok"
                                 aria-hidden="true"></i></a>
                     </div>
+                    <button type="button" class="install-app-btn" data-install-app hidden aria-hidden="true">
+                        <i class="fas fa-download" aria-hidden="true"></i>
+                        <span>Install App</span>
+                    </button>
                 </div>
                 <div class="footer-column">
                     <p class="footer-heading">LINKS</p>

--- a/reviews.html
+++ b/reviews.html
@@ -914,6 +914,10 @@
                             style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok"
                                 aria-hidden="true"></i></a>
                     </div>
+                    <button type="button" class="install-app-btn" data-install-app hidden aria-hidden="true">
+                        <i class="fas fa-download" aria-hidden="true"></i>
+                        <span>Install App</span>
+                    </button>
                 </div>
                 <div class="footer-column">
                     <p class="footer-heading">LINKS</p>

--- a/services.html
+++ b/services.html
@@ -743,6 +743,10 @@
                             style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok"
                                 aria-hidden="true"></i></a>
                     </div>
+                    <button type="button" class="install-app-btn" data-install-app hidden aria-hidden="true">
+                        <i class="fas fa-download" aria-hidden="true"></i>
+                        <span>Install App</span>
+                    </button>
                 </div>
                 <div class="footer-column">
                     <p class="footer-heading">LINKS</p>

--- a/tablet-repair.html
+++ b/tablet-repair.html
@@ -925,6 +925,10 @@
                         <a href="https://www.instagram.com/onlinefixrepairs" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
                         <a href="https://www.tiktok.com/@onlinefix" target="_blank" rel="noopener noreferrer" style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok" aria-hidden="true"></i></a>
                     </div>
+                    <button type="button" class="install-app-btn" data-install-app hidden aria-hidden="true">
+                        <i class="fas fa-download" aria-hidden="true"></i>
+                        <span>Install App</span>
+                    </button>
                 </div>
                 <div class="footer-column">
                     <p class="footer-heading">LINKS</p>

--- a/xbox-repair.html
+++ b/xbox-repair.html
@@ -1277,6 +1277,10 @@
                             style="color: white; margin-right: 1rem;" aria-label="TikTok"><i class="fab fa-tiktok"
                                 aria-hidden="true"></i></a>
                     </div>
+                    <button type="button" class="install-app-btn" data-install-app hidden aria-hidden="true">
+                        <i class="fas fa-download" aria-hidden="true"></i>
+                        <span>Install App</span>
+                    </button>
                 </div>
                 <div class="footer-column">
                     <p class="footer-heading">LINKS</p>


### PR DESCRIPTION
## Summary
- Add discreet PWA install button to the footer of all 14 public pages — hidden by default, reveals only when the browser fires `beforeinstallprompt` (Chromium-based browsers). Zero impact on visitors whose browser doesn't support install.
- Bump `sync-gbp-reviews.yml` to Node 22 so the scheduled GBP sync keeps working after 2 June 2026 when GitHub forces Node 20 off runners.

## Test plan
- [x] Install button hidden by default on all pages
- [x] 44px min-height target size (WCAG 2.5.8)
- [x] Focus ring matches rest of site
- [x] Node 22 available on `ubuntu-latest` runner
- [ ] After merge: confirm next scheduled sync run succeeds with Node 22
- [ ] After merge: verify install button appears in Chrome/Edge once engagement threshold hits

https://claude.ai/code/session_01YHNHBa7NAvBTAyn7fi9pha