### PR TITLE
Harden repair-ticket access tokens and admin auth

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,9 +2,15 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
+    // Admin access is granted via a custom claim (admin == true) set with the
+    // Firebase Admin SDK, with the email allow-list kept as a transitional
+    // fallback. Once the custom claim is provisioned on the admin account,
+    // remove the email branch so admin status no longer depends on a
+    // user-controllable token field.
     function isAdmin() {
       return request.auth != null
-        && request.auth.token.email in ['onlinerepairbooking@gmail.com'];
+        && (request.auth.token.admin == true
+            || request.auth.token.email in ['onlinerepairbooking@gmail.com']);
     }
 
     match /repairs/{repairDoc} {

--- a/new-repair/index.html
+++ b/new-repair/index.html
@@ -867,7 +867,9 @@
             const photoItem = document.createElement('div');
             photoItem.className = 'photo-item';
 
-            const photoId = 'photo_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            const photoSuffixBytes = new Uint8Array(8);
+            crypto.getRandomValues(photoSuffixBytes);
+            const photoId = 'photo_' + Date.now() + '_' + Array.from(photoSuffixBytes, b => b.toString(16).padStart(2, '0')).join('');
             photoItem.innerHTML = `
                 <img src="${escapeHTML(src)}" alt="Device photo">
                 <button type="button" class="photo-remove" onclick="removePhoto('${escapeHTML(photoId)}')">×</button>
@@ -924,10 +926,12 @@
                 const formData = new FormData(document.getElementById('repair-form'));
                 const data = Object.fromEntries(formData);
 
-                // Generate repair ID
-                const randomPart = crypto.getRandomValues(new Uint32Array(1))[0].toString(36).toUpperCase();
-                const timePart = Date.now().toString(36).slice(-4).toUpperCase();
-                const repairId = 'REP_' + timePart + randomPart.slice(0, 4);
+                // Generate repair ID. The ID is the only access token guarding
+                // ticket data (see firestore.rules / storage.rules), so it must be
+                // unguessable: 128 bits of CSPRNG output rendered as 32 hex chars.
+                const idBytes = new Uint8Array(16);
+                crypto.getRandomValues(idBytes);
+                const repairId = 'REP_' + Array.from(idBytes, b => b.toString(16).padStart(2, '0')).join('').toUpperCase();
 
                 // Upload photos if any
                 const photoUrls = [];


### PR DESCRIPTION
The repairId is the only credential gating Firestore reads (per the public list rule in firestore.rules) and Storage reads of repair photos, so its entropy directly determines whether ticket data is brute-forceable. The previous generator produced ~20 bits of randomness on the random segment, well within enumeration range for an attacker who knows roughly when a ticket was created.

Changes:
- new-repair: generate repairId from 128 bits of crypto.getRandomValues rendered as 32 hex chars, making guessing infeasible.
- new-repair: replace Math.random in the photo-element id with crypto.getRandomValues so per-photo paths inside a repair are also unguessable.
- firestore.rules: accept either a Firebase custom claim (admin == true) or the existing email allow-list, so admin status can move off the user-controllable token.email field once the claim is provisioned.

Operational follow-ups (not in this commit):
- Enforce 2FA on the admin Google account.
- After setting the admin custom claim via the Firebase Admin SDK, remove the email branch from isAdmin().
- Verify production response headers actually carry the policies in _headers (GitHub Pages ignores _headers; needs Cloudflare Pages or a Cloudflare Transform Rule in front).

https://claude.ai/code/session_01AZwaaWQ2rm3EUwyPGqcFYa