### PR TITLE
Document Cloudflare Transform Rule overrides _headers CSP

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,6 +1,12 @@
 # HTTP Security Headers
 # Works with: Cloudflare Pages, Netlify
 # For GitHub Pages: configure via Cloudflare proxy Transform Rules
+#
+# NOTE: Production onlinefix.co.uk serves Content-Security-Policy from a
+# Cloudflare Transform Rule on the zone, which overrides this file. When
+# updating CSP, edit BOTH this file AND the Transform Rule (Cloudflare
+# dashboard -> onlinefix.co.uk zone -> Rules -> Transform Rules ->
+# Modify Response Header), or the change will not reach production.
 
 /*
   X-Frame-Options: DENY


### PR DESCRIPTION
## Summary
- PR #60 updated `_headers` and per-page meta CSPs to allow `*.google-analytics.com`, but production still blocked `region1.google-analytics.com`.
- Root cause: a Cloudflare Transform Rule on the `onlinefix.co.uk` zone injects its own `Content-Security-Policy` response header, overriding `_headers`. The Transform Rule still had the old `www.google-analytics.com` value.
- The Transform Rule has now been updated in Cloudflare; the live header now contains `*.google-analytics.com` and `region1.google-analytics.com` is no longer CSP-blocked.

## Change in this PR
Adds a `NOTE` comment at the top of `_headers` warning that production CSP comes from the zone-level Transform Rule, so a future editor knows both must be kept in sync.

## Test plan
- [x] Verified live `Content-Security-Policy` response header on `https://onlinefix.co.uk/` now contains `https://*.google-analytics.com` in `script-src`, `img-src`, and `connect-src`.
- [x] Verified browser console no longer shows the `region1.google-analytics.com` CSP violation.

https://claude.ai/code/session_01QLKce6dvfL3iS3zu9bDdsS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLKce6dvfL3iS3zu9bDdsS)_