### PR TITLE
Drop App Check from tracking page to unbreak customer links

### DIFF
--- a/track/index.html
+++ b/track/index.html
@@ -15,7 +15,6 @@
     <!-- Firebase -->
     <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-app-check-compat.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js"
         integrity="sha512-fD9DI5bZwQxOi7MhYWnnNPlvXdp/2Pj3XSTRrFs5FQa4mizyGLnJcN6tuvUS6LbmgN1ut+XGSABKvjN0H6Aoow=="
@@ -877,10 +876,15 @@
             appId: "1:382934797751:web:5ac8a9c87d68a17b4cec32"
         };
 
-        // Initialize Firebase
+        // Initialize Firebase. App Check intentionally not used here:
+        // the tracking page is a single-doc lookup by an unguessable
+        // random repair ID, and firestore.rules already restricts public
+        // list queries to limit <= 1. App Check kept tripping the
+        // production CSP (no www.google.com/recaptcha.net in connect-src
+        // from the Cloudflare Transform Rule), then getting throttled
+        // for 24h, which broke every customer tracking link. See
+        // commit 9aa300b for the same fix on admin/index.html.
         firebase.initializeApp(firebaseConfig);
-        const appCheck = firebase.appCheck();
-        appCheck.activate(new firebase.appCheck.ReCaptchaEnterpriseProvider('6LdZJRIsAAAAAOx4EZqupxMVvX4B3u3YlK5ez-3r'), true);
         const db = firebase.firestore();
 
         // Status definitions


### PR DESCRIPTION
Same failure mode as commit 9aa300b on admin/index.html: the production CSP (served by the Cloudflare Transform Rule, which overrides the meta tag in track/index.html) does not list www.google.com / www.recaptcha.net in connect-src, so the reCAPTCHA Enterprise token fetch was blocked. Repeated failures triggered Google's 24h App Check throttle, after which Firestore rejected every public tracking lookup with 'Missing or insufficient permissions' and customers saw the 'Repair Record Not Found' page on valid tracking links.

The tracking page is a single-doc lookup by a random unguessable repair ID. firestore.rules already limits public list queries to limit <= 1 on a == filter for the repairId field, which is the actual security boundary. Removing App Check here trades a marginal anti-bot signal for a working customer flow.

Operational follow-up (manual, in Firebase Console / Cloudflare):
 - Confirm App Check enforcement is OFF for Firestore (or set to 'Unenforced'); with enforcement on, public reads still fail with no token regardless of the SDK being loaded.
 - If App Check is wanted long-term, fix the Cloudflare Transform Rule's CSP to include https://www.google.com and https://www.recaptcha.net in connect-src, wait 24h for the throttle to clear, then re-add the SDK.