### PR TITLE
Restore original hero mobile rule and bust SW cache

### DIFF
--- a/index.html
+++ b/index.html
@@ -735,8 +735,6 @@
                 justify-content: center;
                 text-align: center;
                 padding-top: 0;
-                min-height: 80vh;
-                min-height: 80svh;
             }
         .header {
                 padding: 1.5rem 1rem;

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@
    - Never caches /admin/ (auth-gated, always fresh)
 */
 
-const SW_VERSION = 'onlinefix-v3';
+const SW_VERSION = 'onlinefix-v4';
 const SHELL_CACHE = `shell-${SW_VERSION}`;
 const RUNTIME_CACHE = `runtime-${SW_VERSION}`;
 


### PR DESCRIPTION
- Reverted index hero mobile padding override (min-height 80svh added earlier was making the hero too short on some phones and pushing the ONLINEFIX header box too close to the fixed navbar).
- Bumped SW_VERSION to v4 so devices still serving cached old core.min.css (which had the long footer LINKS column) pick up the current compact rule on their next visit.