### PR TITLE
Fire stat counters immediately for above-the-fold case

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -127,20 +127,39 @@ document.addEventListener('DOMContentLoaded', () => {
         requestAnimationFrame(tick);
     };
 
-    if (!('IntersectionObserver' in window)) {
-        counters.forEach(animate);
-        return;
-    }
+    const inViewport = (el) => {
+        const rect = el.getBoundingClientRect();
+        return rect.top < (window.innerHeight || document.documentElement.clientHeight) && rect.bottom > 0;
+    };
 
-    const obs = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-            if (entry.isIntersecting) {
-                animate(entry.target);
-                obs.unobserve(entry.target);
-            }
-        });
-    }, { threshold: 0.3 });
-    counters.forEach(c => obs.observe(c));
+    const triggered = new WeakSet();
+    const fire = (el) => {
+        if (triggered.has(el)) return;
+        triggered.add(el);
+        animate(el);
+    };
+
+    // Fire immediately for any counter already in view (covers the common case
+    // where the stats section is above the fold). iOS Safari has historically
+    // been unreliable about firing IntersectionObserver for already-visible
+    // elements, so this is the primary trigger.
+    counters.forEach(c => { if (inViewport(c)) fire(c); });
+
+    // For anything still below the fold, observe and fire on scroll-in.
+    if ('IntersectionObserver' in window) {
+        const obs = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    fire(entry.target);
+                    obs.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.2 });
+        counters.forEach(c => { if (!triggered.has(c)) obs.observe(c); });
+    } else {
+        // No IO support — just fire everything.
+        counters.forEach(fire);
+    }
 });
 
 // Mobile scroll nudge (for pages with horizontal-scrolling grids)

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@
    - Never caches /admin/ (auth-gated, always fresh)
 */
 
-const SW_VERSION = 'onlinefix-v4';
+const SW_VERSION = 'onlinefix-v5';
 const SHELL_CACHE = `shell-${SW_VERSION}`;
 const RUNTIME_CACHE = `runtime-${SW_VERSION}`;
 


### PR DESCRIPTION
Reviews page numbers were still showing 0. Root cause: on the reviews page the stats section is above the fold, and iOS Safari sometimes won't fire IntersectionObserver for elements already intersecting the viewport at observation time — especially when wrapped in a parent mid-transition (the .fade-in animation).

Now we check getBoundingClientRect on DOMContentLoaded and animate any counter that's already visible, then attach IntersectionObserver only for counters that are still below the fold. A WeakSet keeps fire() idempotent so the IO callback can't re-trigger an already-animated counter.

Bumped SW_VERSION to v5 so devices still serving cached pre-counter core.js pick up the working version on next visit.