### PR TITLE
Remove service-card hover hazard-stripe and use monospace font

### DIFF
--- a/index.html
+++ b/index.html
@@ -624,35 +624,13 @@
             border: 2px solid var(--hex-black);
             padding: 2rem;
             position: relative;
-            transition: all 0.2s;
             height: 100%;
+            font-family: 'Courier New', Courier, monospace;
         }
 
-        @media (hover: hover) {
-        .service-card:hover {
-                background: var(--hazard-stripe);
-                transform: translateY(-5px);
-                box-shadow: 8px 8px 0 #000;
-            }
-        .service-card:hover .service-title,
-            .service-card:hover .service-link,
-            .service-card:hover p {
-                background: var(--hex-white);
-                color: var(--hex-black);
-                box-shadow: 4px 4px 0 var(--hex-black);
-                padding: 2px 5px;
-                display: inline-block;
-                position: relative;
-                z-index: 2;
-            }
-        .service-card:hover .service-icon {
-                color: var(--hex-white);
-                background: var(--hex-black);
-                padding: 10px;
-                display: inline-block;
-                box-shadow: 4px 4px 0 var(--hex-white);
-            }
-    }
+        .service-card p {
+            font-family: 'Courier New', Courier, monospace;
+        }
 
         .service-icon {
             font-size: 2rem;

--- a/services.html
+++ b/services.html
@@ -205,38 +205,14 @@
             border: 2px solid var(--hex-black);
             padding: 2rem;
             position: relative;
-            transition: all 0.2s;
             display: flex;
             flex-direction: column;
+            font-family: 'Courier New', Courier, monospace;
         }
 
-        @media (hover: hover) {
-        .service-card:hover {
-                background: var(--hazard-stripe);
-                transform: translateY(-5px);
-                box-shadow: 8px 8px 0 #000;
-            }
-        .service-card:hover .service-title,
-            .service-card:hover .service-description,
-            .service-card:hover .service-features li,
-            .service-card:hover .price-amount,
-            .service-card:hover .price-text {
-                background: var(--hex-white);
-                color: var(--hex-black);
-                box-shadow: 4px 4px 0 var(--hex-black);
-                padding: 2px 5px;
-                display: inline-block;
-                position: relative;
-                z-index: 2;
-            }
-        .service-card:hover .service-icon {
-                color: var(--hex-white);
-                background: var(--hex-black);
-                padding: 10px;
-                display: inline-block;
-                box-shadow: 4px 4px 0 var(--hex-white);
-            }
-    }
+        .service-card .service-description {
+            font-family: 'Courier New', Courier, monospace;
+        }
 
         .service-card::before {
             content: "SERVICE";


### PR DESCRIPTION
Hover transformed the cards into hazard-striped panels that obscured content and added unnecessary motion. Switch the card text to Courier New so it matches the workflow cards above.