### PR TITLE
Replace per-card Get Quote buttons on repair pages with one bar

### DIFF
--- a/console-repair.html
+++ b/console-repair.html
@@ -503,8 +503,40 @@
 
         .issues-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+            grid-template-columns: repeat(3, 1fr);
             gap: 20px;
+        }
+
+        @media (max-width: 900px) {
+            .issues-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .issues-grid-cta {
+            grid-column: 1 / -1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.6rem;
+            background: var(--gradient-blue);
+            color: var(--hex-white);
+            padding: 1.25rem 2rem;
+            text-decoration: none;
+            font-weight: 800;
+            text-transform: uppercase;
+            font-size: 1rem;
+            border: 2px solid var(--hex-black);
+            box-shadow: 6px 6px 0 var(--hex-black);
+            transition: all 0.1s;
+            cursor: pointer;
+        }
+
+        @media (hover: hover) {
+            .issues-grid-cta:hover {
+                transform: translate(4px, 4px);
+                box-shadow: 2px 2px 0 var(--hex-black);
+            }
         }
 
         .issue-card {
@@ -609,31 +641,6 @@
             font-weight: 900;
             color: var(--hex-black);
         }
-
-        .issue-cta {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            background: var(--gradient-blue);
-            color: var(--hex-white);
-            padding: 1rem;
-            text-decoration: none;
-            font-weight: 800;
-            text-transform: uppercase;
-            font-size: 0.9rem;
-            border: 2px solid var(--hex-black);
-            transition: all 0.1s;
-            cursor: pointer;
-            gap: 0.5rem;
-            width: 100%;
-        }
-
-        @media (hover: hover) {
-        .issue-cta:hover {
-                transform: translate(4px, 4px);
-                box-shadow: -4px -4px 0 var(--hex-black);
-            }
-    }
 
         .why-section {
             padding: 0 0 4rem;
@@ -980,10 +987,10 @@
         .issue-price {
                 font-size: 1.3rem;
             }
-        .issue-cta {
-                padding: 0.9rem;
-                font-size: 0.85rem;
-                min-height: 48px;
+        .issues-grid-cta {
+                padding: 1rem;
+                font-size: 0.9rem;
+                box-shadow: 4px 4px 0 var(--hex-black);
             }
         .why-grid {
                 grid-template-columns: repeat(2, 1fr);
@@ -1229,8 +1236,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">From &pound;60</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Book HDMI Repair</a>
                         </div>
                     </article>
 
@@ -1257,8 +1262,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;55</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Book Drive Repair</a>
                         </div>
                     </article>
 
@@ -1287,10 +1290,12 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">From &pound;35</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Book Power Repair</a>
                         </div>
                     </article>
+
+                    <a href="tel:+447940730537" class="issues-grid-cta">
+                        <i class="fas fa-phone" aria-hidden="true"></i> Get a Quote — Call 07940 730537
+                    </a>
 
                     <!-- OVERHEATING -->
                     <article class="issue-card fade-in" data-issue-num="ISSUE_04">
@@ -1317,8 +1322,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">From &pound;30</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Book Thermal Service</a>
                         </div>
                     </article>
 
@@ -1345,8 +1348,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;30</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Book Switch Repair</a>
                         </div>
                     </article>
 
@@ -1375,8 +1376,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">From &pound;30</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Book Xbox Repair</a>
                         </div>
                     </article>
                 </div>

--- a/data-recovery.html
+++ b/data-recovery.html
@@ -371,7 +371,10 @@
 
         .issues-section { padding: 0 0 4rem; border-top: 2px solid var(--hex-black); background: var(--hex-white); overflow: hidden; }
 
-        .issues-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(350px, 1fr)); gap: 20px; }
+        .issues-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+        @media (max-width: 900px) { .issues-grid { grid-template-columns: 1fr; } }
+        .issues-grid-cta { grid-column: 1 / -1; display: flex; align-items: center; justify-content: center; gap: 0.6rem; background: var(--gradient-blue); color: var(--hex-white); padding: 1.25rem 2rem; text-decoration: none; font-weight: 800; text-transform: uppercase; font-size: 1rem; border: 2px solid var(--hex-black); box-shadow: 6px 6px 0 var(--hex-black); transition: all 0.1s; cursor: pointer; }
+        @media (hover: hover) { .issues-grid-cta:hover { transform: translate(4px, 4px); box-shadow: 2px 2px 0 var(--hex-black); } }
 
         .issue-card { background: var(--hex-white); border: 2px solid var(--hex-black); padding: 2.5rem; position: relative; transition: all 0.2s; display: flex; flex-direction: column; }
 
@@ -400,12 +403,6 @@
         .price-text { font-family: monospace; font-size: 0.8rem; color: #666; margin-bottom: 0.3rem; text-transform: uppercase; }
 
         .issue-price { font-size: 1.5rem; font-weight: 900; color: var(--hex-black); }
-
-        .issue-cta { display: flex; align-items: center; justify-content: center; background: var(--gradient-blue); color: var(--hex-white); padding: 1rem; text-decoration: none; font-weight: 800; text-transform: uppercase; font-size: 0.9rem; border: 2px solid var(--hex-black); transition: all 0.1s; cursor: pointer; gap: 0.5rem; width: 100%; }
-
-        @media (hover: hover) {
-        .issue-cta:hover { transform: translate(4px, 4px); box-shadow: -4px -4px 0 var(--hex-black); }
-    }
 
         .why-section { padding: 0 0 4rem; border-top: 2px solid var(--hex-black); background: var(--hex-white); overflow: hidden; }
 
@@ -505,7 +502,7 @@
         .issue-symptoms li { font-size: 0.8rem; padding: 0.3rem 0; }
         .issue-pricing { padding: 0.75rem; }
         .issue-price { font-size: 1.3rem; }
-        .issue-cta { padding: 0.9rem; font-size: 0.85rem; min-height: 48px; }
+        .issues-grid-cta { padding: 1rem; font-size: 0.9rem; box-shadow: 4px 4px 0 var(--hex-black); }
         .why-grid { grid-template-columns: repeat(2, 1fr); }
         .why-item:nth-child(2) { border-right: none; }
         .why-item:nth-child(1), .why-item:nth-child(2) { border-bottom: 2px solid var(--hex-black); }
@@ -634,7 +631,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;45</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Recovery</a>
                         </div>
                     </article>
 
@@ -658,7 +654,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;55</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Recovery</a>
                         </div>
                     </article>
 
@@ -682,9 +677,12 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;65</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Recovery</a>
                         </div>
                     </article>
+
+                    <a href="tel:+447940730537" class="issues-grid-cta">
+                        <i class="fas fa-phone" aria-hidden="true"></i> Get a Quote — Call 07940 730537
+                    </a>
 
                     <!-- WATER & FIRE DAMAGE -->
                     <article class="issue-card fade-in" data-issue-num="CASE_04">
@@ -706,7 +704,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;75</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Recovery</a>
                         </div>
                     </article>
 
@@ -730,7 +727,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;45</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Recovery</a>
                         </div>
                     </article>
 
@@ -754,7 +750,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;85</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Call to Book Recovery</a>
                         </div>
                     </article>
                 </div>

--- a/iphone-repair.html
+++ b/iphone-repair.html
@@ -438,7 +438,10 @@
 
         .issues-section { padding: 0 0 4rem; border-top: 2px solid var(--hex-black); background: var(--hex-white); overflow: hidden; }
 
-        .issues-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(350px, 1fr)); gap: 20px; }
+        .issues-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+        @media (max-width: 900px) { .issues-grid { grid-template-columns: 1fr; } }
+        .issues-grid-cta { grid-column: 1 / -1; display: flex; align-items: center; justify-content: center; gap: 0.6rem; background: var(--gradient-blue); color: var(--hex-white); padding: 1.25rem 2rem; text-decoration: none; font-weight: 800; text-transform: uppercase; font-size: 1rem; border: 2px solid var(--hex-black); box-shadow: 6px 6px 0 var(--hex-black); transition: all 0.1s; cursor: pointer; }
+        @media (hover: hover) { .issues-grid-cta:hover { transform: translate(4px, 4px); box-shadow: 2px 2px 0 var(--hex-black); } }
 
         .issue-card { background: var(--hex-white); border: 2px solid var(--hex-black); padding: 2.5rem; position: relative; transition: all 0.2s; display: flex; flex-direction: column; }
 
@@ -467,12 +470,6 @@
         .price-text { font-family: monospace; font-size: 0.8rem; color: #666; margin-bottom: 0.3rem; text-transform: uppercase; }
 
         .issue-price { font-size: 1.5rem; font-weight: 900; color: var(--hex-black); }
-
-        .issue-cta { display: flex; align-items: center; justify-content: center; background: var(--gradient-blue); color: var(--hex-white); padding: 1rem; text-decoration: none; font-weight: 800; text-transform: uppercase; font-size: 0.9rem; border: 2px solid var(--hex-black); transition: all 0.1s; cursor: pointer; gap: 0.5rem; width: 100%; }
-
-        @media (hover: hover) {
-        .issue-cta:hover { transform: translate(4px, 4px); box-shadow: -4px -4px 0 var(--hex-black); }
-    }
 
         .why-section { padding: 0 0 4rem; border-top: 2px solid var(--hex-black); background: var(--hex-white); overflow: hidden; }
 
@@ -572,7 +569,7 @@
         .issue-symptoms li { font-size: 0.8rem; padding: 0.3rem 0; }
         .issue-pricing { padding: 0.75rem; }
         .issue-price { font-size: 1.3rem; }
-        .issue-cta { padding: 0.9rem; font-size: 0.85rem; min-height: 48px; }
+        .issues-grid-cta { padding: 1rem; font-size: 0.9rem; box-shadow: 4px 4px 0 var(--hex-black); }
         .why-grid { grid-template-columns: repeat(2, 1fr); }
         .why-item:nth-child(2) { border-right: none; }
         .why-item:nth-child(1), .why-item:nth-child(2) { border-bottom: 2px solid var(--hex-black); }
@@ -717,7 +714,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;45</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Screen Repair</a>
                         </div>
                     </article>
 
@@ -741,7 +737,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;35</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Battery Swap</a>
                         </div>
                     </article>
 
@@ -765,9 +760,12 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;45</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Port Repair</a>
                         </div>
                     </article>
+
+                    <a href="tel:+447940730537" class="issues-grid-cta">
+                        <i class="fas fa-phone" aria-hidden="true"></i> Get a Quote — Call 07940 730537
+                    </a>
 
                     <!-- WATER DAMAGE -->
                     <article class="issue-card fade-in" data-issue-num="ISSUE_04">
@@ -789,7 +787,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;55</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Water Damage Repair</a>
                         </div>
                     </article>
 
@@ -813,7 +810,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;45</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Glass Repair</a>
                         </div>
                     </article>
 
@@ -837,7 +833,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;40</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Camera Repair</a>
                         </div>
                     </article>
                 </div>

--- a/macbook-repair.html
+++ b/macbook-repair.html
@@ -371,7 +371,10 @@
 
         .issues-section { padding: 0 0 4rem; border-top: 2px solid var(--hex-black); background: var(--hex-white); overflow: hidden; }
 
-        .issues-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(350px, 1fr)); gap: 20px; }
+        .issues-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+        @media (max-width: 900px) { .issues-grid { grid-template-columns: 1fr; } }
+        .issues-grid-cta { grid-column: 1 / -1; display: flex; align-items: center; justify-content: center; gap: 0.6rem; background: var(--gradient-blue); color: var(--hex-white); padding: 1.25rem 2rem; text-decoration: none; font-weight: 800; text-transform: uppercase; font-size: 1rem; border: 2px solid var(--hex-black); box-shadow: 6px 6px 0 var(--hex-black); transition: all 0.1s; cursor: pointer; }
+        @media (hover: hover) { .issues-grid-cta:hover { transform: translate(4px, 4px); box-shadow: 2px 2px 0 var(--hex-black); } }
 
         .issue-card { background: var(--hex-white); border: 2px solid var(--hex-black); padding: 2.5rem; position: relative; transition: all 0.2s; display: flex; flex-direction: column; }
 
@@ -400,12 +403,6 @@
         .price-text { font-family: monospace; font-size: 0.8rem; color: #666; margin-bottom: 0.3rem; text-transform: uppercase; }
 
         .issue-price { font-size: 1.5rem; font-weight: 900; color: var(--hex-black); }
-
-        .issue-cta { display: flex; align-items: center; justify-content: center; background: var(--gradient-blue); color: var(--hex-white); padding: 1rem; text-decoration: none; font-weight: 800; text-transform: uppercase; font-size: 0.9rem; border: 2px solid var(--hex-black); transition: all 0.1s; cursor: pointer; gap: 0.5rem; width: 100%; }
-
-        @media (hover: hover) {
-        .issue-cta:hover { transform: translate(4px, 4px); box-shadow: -4px -4px 0 var(--hex-black); }
-    }
 
         .why-section { padding: 0 0 4rem; border-top: 2px solid var(--hex-black); background: var(--hex-white); overflow: hidden; }
 
@@ -505,7 +502,7 @@
         .issue-symptoms li { font-size: 0.8rem; padding: 0.3rem 0; }
         .issue-pricing { padding: 0.75rem; }
         .issue-price { font-size: 1.3rem; }
-        .issue-cta { padding: 0.9rem; font-size: 0.85rem; min-height: 48px; }
+        .issues-grid-cta { padding: 1rem; font-size: 0.9rem; box-shadow: 4px 4px 0 var(--hex-black); }
         .why-grid { grid-template-columns: repeat(2, 1fr); }
         .why-item:nth-child(2) { border-right: none; }
         .why-item:nth-child(1), .why-item:nth-child(2) { border-bottom: 2px solid var(--hex-black); }
@@ -636,7 +633,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;95</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Board Repair</a>
                         </div>
                     </article>
 
@@ -660,7 +656,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;149</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Screen Repair</a>
                         </div>
                     </article>
 
@@ -684,9 +679,12 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;79</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Battery Swap</a>
                         </div>
                     </article>
+
+                    <a href="tel:+447940730537" class="issues-grid-cta">
+                        <i class="fas fa-phone" aria-hidden="true"></i> Get a Quote — Call 07940 730537
+                    </a>
 
                     <!-- KEYBOARD REPAIR -->
                     <article class="issue-card fade-in" data-issue-num="ISSUE_04">
@@ -708,7 +706,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;89</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Keyboard Fix</a>
                         </div>
                     </article>
 
@@ -732,7 +729,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;69</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book SSD Upgrade</a>
                         </div>
                     </article>
 
@@ -756,7 +752,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;85</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Water Damage Repair</a>
                         </div>
                     </article>
                 </div>

--- a/pc-repair.html
+++ b/pc-repair.html
@@ -501,8 +501,40 @@
 
         .issues-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+            grid-template-columns: repeat(3, 1fr);
             gap: 20px;
+        }
+
+        @media (max-width: 900px) {
+            .issues-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .issues-grid-cta {
+            grid-column: 1 / -1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.6rem;
+            background: var(--gradient-blue);
+            color: var(--hex-white);
+            padding: 1.25rem 2rem;
+            text-decoration: none;
+            font-weight: 800;
+            text-transform: uppercase;
+            font-size: 1rem;
+            border: 2px solid var(--hex-black);
+            box-shadow: 6px 6px 0 var(--hex-black);
+            transition: all 0.1s;
+            cursor: pointer;
+        }
+
+        @media (hover: hover) {
+            .issues-grid-cta:hover {
+                transform: translate(4px, 4px);
+                box-shadow: 2px 2px 0 var(--hex-black);
+            }
         }
 
         .issue-card {
@@ -607,31 +639,6 @@
             font-weight: 900;
             color: var(--hex-black);
         }
-
-        .issue-cta {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            background: var(--gradient-blue);
-            color: var(--hex-white);
-            padding: 1rem;
-            text-decoration: none;
-            font-weight: 800;
-            text-transform: uppercase;
-            font-size: 0.9rem;
-            border: 2px solid var(--hex-black);
-            transition: all 0.1s;
-            cursor: pointer;
-            gap: 0.5rem;
-            width: 100%;
-        }
-
-        @media (hover: hover) {
-        .issue-cta:hover {
-                transform: translate(4px, 4px);
-                box-shadow: -4px -4px 0 var(--hex-black);
-            }
-    }
 
         .why-section {
             padding: 0 0 4rem;
@@ -978,10 +985,10 @@
         .issue-price {
                 font-size: 1.3rem;
             }
-        .issue-cta {
-                padding: 0.9rem;
-                font-size: 0.85rem;
-                min-height: 48px;
+        .issues-grid-cta {
+                padding: 1rem;
+                font-size: 0.9rem;
+                box-shadow: 4px 4px 0 var(--hex-black);
             }
         .why-grid {
                 grid-template-columns: repeat(2, 1fr);
@@ -1227,8 +1234,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;30</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Call to Book Diagnosis</a>
                         </div>
                     </article>
 
@@ -1256,8 +1261,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;35</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Call to Book Virus Removal</a>
                         </div>
                     </article>
 
@@ -1285,10 +1288,12 @@
                                 <div class="price-text">Starting From (labour)</div>
                                 <div class="issue-price">&pound;40</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Call to Book SSD Upgrade</a>
                         </div>
                     </article>
+
+                    <a href="tel:+447940730537" class="issues-grid-cta">
+                        <i class="fas fa-phone" aria-hidden="true"></i> Get a Quote — Call 07940 730537
+                    </a>
 
                     <!-- RAM & COMPONENT UPGRADE -->
                     <article class="issue-card fade-in" data-issue-num="ISSUE_04">
@@ -1314,8 +1319,6 @@
                                 <div class="price-text">Starting From (labour)</div>
                                 <div class="issue-price">&pound;25</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Call to Book Upgrade</a>
                         </div>
                     </article>
 
@@ -1343,8 +1346,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;35</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Call to Book Windows Install</a>
                         </div>
                     </article>
 
@@ -1372,8 +1373,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;30</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Call to Book Cooling Repair</a>
                         </div>
                     </article>
                 </div>

--- a/playstation-repair.html
+++ b/playstation-repair.html
@@ -215,8 +215,40 @@
 
         .issues-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+            grid-template-columns: repeat(2, 1fr);
             gap: 20px;
+        }
+
+        @media (max-width: 768px) {
+            .issues-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .issues-grid-cta {
+            grid-column: 1 / -1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.6rem;
+            background: var(--gradient-blue);
+            color: var(--hex-white);
+            padding: 1.25rem 2rem;
+            text-decoration: none;
+            font-weight: 800;
+            text-transform: uppercase;
+            font-size: 1rem;
+            border: 2px solid var(--hex-black);
+            box-shadow: 6px 6px 0 var(--hex-black);
+            transition: all 0.1s;
+            cursor: pointer;
+        }
+
+        @media (hover: hover) {
+            .issues-grid-cta:hover {
+                transform: translate(4px, 4px);
+                box-shadow: 2px 2px 0 var(--hex-black);
+            }
         }
 
         .issue-card {
@@ -332,31 +364,6 @@
             font-weight: 900;
             color: var(--hex-black);
         }
-
-        .issue-cta {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            background: var(--gradient-blue);
-            color: var(--hex-white);
-            padding: 1rem;
-            text-decoration: none;
-            font-weight: 800;
-            text-transform: uppercase;
-            font-size: 0.9rem;
-            border: 2px solid var(--hex-black);
-            transition: all 0.1s;
-            cursor: pointer;
-            gap: 0.5rem;
-            width: 100%;
-        }
-
-        @media (hover: hover) {
-        .issue-cta:hover {
-                transform: translate(4px, 4px);
-                box-shadow: -4px -4px 0 var(--hex-black);
-            }
-    }
 
         .why-section {
             padding: 0 0 4rem;
@@ -703,10 +710,10 @@
         .issue-price {
                 font-size: 1.3rem;
             }
-        .issue-cta {
-                padding: 0.9rem;
-                font-size: 0.85rem;
-                min-height: 48px;
+        .issues-grid-cta {
+                padding: 1rem;
+                font-size: 0.9rem;
+                box-shadow: 4px 4px 0 var(--hex-black);
             }
         .why-grid {
                 grid-template-columns: repeat(2, 1fr);
@@ -944,8 +951,6 @@
                                 <div class="price-text">PS5: &pound;80 | PS4 from &pound;60</div>
                                 <div class="issue-price">from &pound;60</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Book HDMI Repair</a>
                         </div>
                     </article>
 
@@ -972,10 +977,12 @@
                                 <div class="price-text">PS5: &pound;110 | PS4 from &pound;55</div>
                                 <div class="issue-price">from &pound;55</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Book Drive Repair</a>
                         </div>
                     </article>
+
+                    <a href="tel:+447940730537" class="issues-grid-cta">
+                        <i class="fas fa-phone" aria-hidden="true"></i> Get a Quote — Call 07940 730537
+                    </a>
 
                     <!-- PLAYSTATION BLUE LIGHT OF DEATH -->
                     <article class="issue-card fade-in" data-issue-num="ISSUE_03">
@@ -1001,8 +1008,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;90</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Book BLOD Repair</a>
                         </div>
                     </article>
 
@@ -1031,8 +1036,6 @@
                                 <div class="price-text">PS5: &pound;60 | PS4 from &pound;30</div>
                                 <div class="issue-price">from &pound;30</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Book Thermal Service</a>
                         </div>
                     </article>
                 </div>

--- a/tablet-repair.html
+++ b/tablet-repair.html
@@ -371,7 +371,10 @@
 
         .issues-section { padding: 0 0 4rem; border-top: 2px solid var(--hex-black); background: var(--hex-white); overflow: hidden; }
 
-        .issues-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(350px, 1fr)); gap: 20px; }
+        .issues-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+        @media (max-width: 900px) { .issues-grid { grid-template-columns: 1fr; } }
+        .issues-grid-cta { grid-column: 1 / -1; display: flex; align-items: center; justify-content: center; gap: 0.6rem; background: var(--gradient-blue); color: var(--hex-white); padding: 1.25rem 2rem; text-decoration: none; font-weight: 800; text-transform: uppercase; font-size: 1rem; border: 2px solid var(--hex-black); box-shadow: 6px 6px 0 var(--hex-black); transition: all 0.1s; cursor: pointer; }
+        @media (hover: hover) { .issues-grid-cta:hover { transform: translate(4px, 4px); box-shadow: 2px 2px 0 var(--hex-black); } }
 
         .issue-card { background: var(--hex-white); border: 2px solid var(--hex-black); padding: 2.5rem; position: relative; transition: all 0.2s; display: flex; flex-direction: column; }
 
@@ -400,12 +403,6 @@
         .price-text { font-family: monospace; font-size: 0.8rem; color: #666; margin-bottom: 0.3rem; text-transform: uppercase; }
 
         .issue-price { font-size: 1.5rem; font-weight: 900; color: var(--hex-black); }
-
-        .issue-cta { display: flex; align-items: center; justify-content: center; background: var(--gradient-blue); color: var(--hex-white); padding: 1rem; text-decoration: none; font-weight: 800; text-transform: uppercase; font-size: 0.9rem; border: 2px solid var(--hex-black); transition: all 0.1s; cursor: pointer; gap: 0.5rem; width: 100%; }
-
-        @media (hover: hover) {
-        .issue-cta:hover { transform: translate(4px, 4px); box-shadow: -4px -4px 0 var(--hex-black); }
-    }
 
         .why-section { padding: 0 0 4rem; border-top: 2px solid var(--hex-black); background: var(--hex-white); overflow: hidden; }
 
@@ -505,7 +502,7 @@
         .issue-symptoms li { font-size: 0.8rem; padding: 0.3rem 0; }
         .issue-pricing { padding: 0.75rem; }
         .issue-price { font-size: 1.3rem; }
-        .issue-cta { padding: 0.9rem; font-size: 0.85rem; min-height: 48px; }
+        .issues-grid-cta { padding: 1rem; font-size: 0.9rem; box-shadow: 4px 4px 0 var(--hex-black); }
         .why-grid { grid-template-columns: repeat(2, 1fr); }
         .why-item:nth-child(2) { border-right: none; }
         .why-item:nth-child(1), .why-item:nth-child(2) { border-bottom: 2px solid var(--hex-black); }
@@ -634,7 +631,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;55</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Screen Repair</a>
                         </div>
                     </article>
 
@@ -658,7 +654,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;45</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Battery Swap</a>
                         </div>
                     </article>
 
@@ -682,9 +677,12 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;45</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Port Repair</a>
                         </div>
                     </article>
+
+                    <a href="tel:+447940730537" class="issues-grid-cta">
+                        <i class="fas fa-phone" aria-hidden="true"></i> Get a Quote — Call 07940 730537
+                    </a>
 
                     <!-- WATER DAMAGE -->
                     <article class="issue-card fade-in" data-issue-num="ISSUE_04">
@@ -706,7 +704,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;65</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Water Damage Repair</a>
                         </div>
                     </article>
 
@@ -730,7 +727,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;35</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Button / Speaker Repair</a>
                         </div>
                     </article>
 
@@ -754,7 +750,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">&pound;25</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone" aria-hidden="true"></i> Book Software Fix</a>
                         </div>
                     </article>
                 </div>

--- a/xbox-repair.html
+++ b/xbox-repair.html
@@ -215,8 +215,40 @@
 
         .issues-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+            grid-template-columns: repeat(2, 1fr);
             gap: 20px;
+        }
+
+        @media (max-width: 768px) {
+            .issues-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .issues-grid-cta {
+            grid-column: 1 / -1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.6rem;
+            background: var(--gradient-blue);
+            color: var(--hex-white);
+            padding: 1.25rem 2rem;
+            text-decoration: none;
+            font-weight: 800;
+            text-transform: uppercase;
+            font-size: 1rem;
+            border: 2px solid var(--hex-black);
+            box-shadow: 6px 6px 0 var(--hex-black);
+            transition: all 0.1s;
+            cursor: pointer;
+        }
+
+        @media (hover: hover) {
+            .issues-grid-cta:hover {
+                transform: translate(4px, 4px);
+                box-shadow: 2px 2px 0 var(--hex-black);
+            }
         }
 
         .issue-card {
@@ -332,31 +364,6 @@
             font-weight: 900;
             color: var(--hex-black);
         }
-
-        .issue-cta {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            background: var(--gradient-blue);
-            color: var(--hex-white);
-            padding: 1rem;
-            text-decoration: none;
-            font-weight: 800;
-            text-transform: uppercase;
-            font-size: 0.9rem;
-            border: 2px solid var(--hex-black);
-            transition: all 0.1s;
-            cursor: pointer;
-            gap: 0.5rem;
-            width: 100%;
-        }
-
-        @media (hover: hover) {
-        .issue-cta:hover {
-                transform: translate(4px, 4px);
-                box-shadow: -4px -4px 0 var(--hex-black);
-            }
-    }
 
         .why-section {
             padding: 0 0 4rem;
@@ -703,10 +710,10 @@
         .issue-price {
                 font-size: 1.3rem;
             }
-        .issue-cta {
-                padding: 0.9rem;
-                font-size: 0.85rem;
-                min-height: 48px;
+        .issues-grid-cta {
+                padding: 1rem;
+                font-size: 0.9rem;
+                box-shadow: 4px 4px 0 var(--hex-black);
             }
         .why-grid {
                 grid-template-columns: repeat(2, 1fr);
@@ -946,8 +953,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">Series X: &pound;80 | From &pound;60</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Book Xbox HDMI Repair</a>
                         </div>
                     </article>
 
@@ -976,10 +981,12 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">Series X: &pound;60 | From &pound;30</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Book Xbox Clean</a>
                         </div>
                     </article>
+
+                    <a href="tel:+447940730537" class="issues-grid-cta">
+                        <i class="fas fa-phone" aria-hidden="true"></i> Get a Quote — Call 07940 730537
+                    </a>
 
                     <!-- XBOX DISK DRIVE -->
                     <article class="issue-card fade-in" data-issue-num="ISSUE_03">
@@ -1004,8 +1011,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">Series X: &pound;110 | From &pound;55</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Book Xbox Drive Repair</a>
                         </div>
                     </article>
 
@@ -1032,8 +1037,6 @@
                                 <div class="price-text">Starting From</div>
                                 <div class="issue-price">From &pound;65</div>
                             </div>
-                            <a href="tel:+447940730537" class="issue-cta"><i class="fas fa-phone"
-                                    aria-hidden="true"></i> Book Xbox Power Repair</a>
                         </div>
                     </article>
 


### PR DESCRIPTION
Strip the inline issue-cta button from every issue card across the eight repair pages and add a single tel: bar that spans the grid in the middle of the issues catalog. Pin the grid at three columns on the 6-card pages and two columns on playstation/xbox, collapsing to one column on narrower viewports so the bar always lands at a clean midpoint.