### PR TITLE
Collapse platform/system tiles to four boxes

### DIFF
--- a/console-repair.html
+++ b/console-repair.html
@@ -454,7 +454,7 @@
 
         .consoles-grid {
             display: grid;
-            grid-template-columns: repeat(6, 1fr);
+            grid-template-columns: repeat(4, 1fr);
             gap: 0;
             border: 2px solid var(--hex-black);
         }
@@ -942,7 +942,7 @@
         .console-item:nth-child(2n) {
                 border-right: none;
             }
-        .console-item:nth-child(n+5) {
+        .console-item:nth-child(n+3) {
                 border-bottom: none;
             }
         .console-icon {
@@ -1179,19 +1179,11 @@
                 <div class="consoles-grid">
                     <div class="console-item fade-in">
                         <div class="console-icon"><i class="fas fa-gamepad" aria-hidden="true"></i></div>
-                        <div class="console-name">PS5</div>
+                        <div class="console-name">PlayStation 5 / 4 / Pro</div>
                     </div>
                     <div class="console-item fade-in">
                         <div class="console-icon"><i class="fas fa-gamepad" aria-hidden="true"></i></div>
-                        <div class="console-name">PS4 / PS4 Pro</div>
-                    </div>
-                    <div class="console-item fade-in">
-                        <div class="console-icon"><i class="fas fa-gamepad" aria-hidden="true"></i></div>
-                        <div class="console-name">Xbox Series X|S</div>
-                    </div>
-                    <div class="console-item fade-in">
-                        <div class="console-icon"><i class="fas fa-gamepad" aria-hidden="true"></i></div>
-                        <div class="console-name">Xbox One</div>
+                        <div class="console-name">Xbox Series X|S / One</div>
                     </div>
                     <div class="console-item fade-in">
                         <div class="console-icon"><i class="fas fa-gamepad" aria-hidden="true"></i></div>

--- a/pc-repair.html
+++ b/pc-repair.html
@@ -1191,11 +1191,6 @@
                         <div class="model-years">Dell, HP, Lenovo, Acer</div>
                     </div>
                     <div class="model-item fade-in">
-                        <div class="model-icon"><i class="fas fa-tv" aria-hidden="true"></i></div>
-                        <div class="model-name">All-in-One PCs</div>
-                        <div class="model-years">iMac, Surface Studio</div>
-                    </div>
-                    <div class="model-item fade-in">
                         <div class="model-icon"><i class="fas fa-microchip" aria-hidden="true"></i></div>
                         <div class="model-name">Custom Builds</div>
                         <div class="model-years">Upgrades &amp; New Builds</div>


### PR DESCRIPTION
Combine the two PlayStation and two Xbox tiles in console-repair into one PlayStation and one Xbox box, and drop the All-in-One PCs tile in pc-repair so the row fits the existing 4-column grid cleanly.