### PR TITLE
Add /.well-known/security.txt for vulnerability disclosure

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,7 @@
+# Security policy for onlinefix.co.uk
+# See https://securitytxt.org / RFC 9116
+
+Contact: mailto:onlinerepairbooking@gmail.com
+Expires: 2027-05-20T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://onlinefix.co.uk/.well-known/security.txt


### PR DESCRIPTION
Resolves the Cloudflare Security Insights "Security.txt not configured" finding. RFC 9116 file at the standard /.well-known/ path with Contact, Expires (1 year out), Preferred-Languages, and Canonical fields.