### PR TITLE
Equalize testimonial card heights on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -688,6 +688,8 @@
             border: 1px dashed var(--hex-black);
             box-shadow: 5px 5px 0 #ddd;
             height: 100%;
+            display: flex;
+            flex-direction: column;
         }
 
         .stars {
@@ -708,6 +710,8 @@
             color: var(--hex-white);
             display: inline-block;
             padding: 2px 8px;
+            margin-top: auto;
+            align-self: flex-start;
         }
 
         @media (max-width: 1100px) and (min-width: 769px) {
@@ -785,6 +789,7 @@
         .testimonial-card {
                 min-width: 65vw;
                 max-width: 65vw;
+                height: auto;
                 scroll-snap-align: start;
                 flex-shrink: 0;
                 padding: 1.2rem 1rem;


### PR DESCRIPTION
In the mobile horizontal scroll row the cards sized themselves to their text (height:100% resolves to auto there), so each review box was a different height. Cards are now column flexboxes stretched to the tallest sibling, with the reviewer name pinned to the bottom edge — uniform boxes on both mobile and desktop.

https://claude.ai/code/session_0194GoqDPBcHFNrZF3eSUd2H