### PR TITLE
Adjust index FAQ: repair timings, console questions, contact prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,17 +297,10 @@
       "@type": "FAQPage",
       "mainEntity": [{
         "@type": "Question",
-        "name": "What is OnlineFix?",
+        "name": "How long do repairs take at OnlineFix?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "OnlineFix is an independent electronics repair shop in Guildford, Surrey, run by Tomas. We've been fixing phones, laptops, PCs, MacBooks, tablets and gaming consoles since 2018, offering same-day repairs, a 90-day warranty and a no fix, no fee policy."
-        }
-      }, {
-        "@type": "Question",
-        "name": "How long do phone repairs take in Guildford?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Most common repairs at OnlineFix, such as iPhone screen replacements, are completed within one hour. Console HDMI port replacements typically take about 3 hours. For more complex repairs, we provide time estimates upfront."
+          "text": "Our most common repair is the HDMI port replacement, which takes around 2-3 hours. We work on an appointment basis, so this isn't a walk-in, while-you-wait service. More complex work such as level 3 micro-soldering, data recovery, or intermittent problems needing PC diagnostics can take 1-2 weeks."
         }
       }, {
         "@type": "Question",
@@ -328,7 +321,7 @@
         "name": "What devices does OnlineFix repair?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "OnlineFix repairs phones (iPhone, Samsung, Google Pixel), laptops (all brands including HP, Lenovo, Dell, ASUS), MacBooks, PCs and gaming PCs, tablets (iPad, Samsung), and gaming consoles (PS5, PS4, Xbox Series X/S, Xbox One, Nintendo Switch). We also offer data recovery from hard drives, SSDs, and USB devices. Based in Guildford, Surrey, serving Woking, Godalming, and Farnham."
+          "text": "OnlineFix repairs phones (iPhone, Samsung, Google Pixel), laptops (all brands including HP, Lenovo, Dell, ASUS), MacBooks, PCs and gaming PCs, tablets (iPad, Samsung), and gaming consoles (PS5, PS4, Xbox Series X/S, Xbox One, Nintendo Switch). We also offer data recovery and board-level micro-soldering. If your device or issue isn't listed, get in touch by email at hello@onlinefix.uk or phone on 07940 730537 — chances are we can still help. Based in Guildford, Surrey, serving Woking, Godalming, and Farnham."
         }
       }, {
         "@type": "Question",
@@ -339,10 +332,17 @@
         }
       }, {
         "@type": "Question",
-        "name": "How much does a phone or laptop repair cost?",
+        "name": "My console won't show video on the TV — what's wrong?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Repair costs at OnlineFix vary by device and issue. iPhone screen replacements start from £45, laptop screen replacements from £60, PC diagnosis from £30, and console HDMI repairs from £60. We operate a no fix, no fee policy — if we can't repair it, you don't pay. All repairs include a 90-day warranty."
+          "text": "This is usually a damaged HDMI port — the connector can be physically damaged or have pins broken off the board. It's one of our most common repairs. PS5 and Xbox Series X HDMI port replacement is £80."
+        }
+      }, {
+        "@type": "Question",
+        "name": "Why does my PS5 shut down randomly?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Usually one of two things: the console is clogged up with dust, or the liquid metal thermal paste has oxidised and is causing a hotspot on the APU. We fix both with a full clean and thermal paste redo — £70 for PS5."
         }
       }]
     }
@@ -1046,19 +1046,12 @@
                 <h2 class="section-title fade-in" id="faq-heading">FAQ</h2>
                 <div class="faq-container fade-in">
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">WHAT IS ONLINEFIX?</button>
-                        <div class="faq-answer" role="region">
-                            OnlineFix is an independent electronics repair shop in Guildford, Surrey, run by
-                            Tomas. We've been fixing phones, laptops, PCs, MacBooks, tablets and gaming consoles
-                            since 2018, with same-day service, a 90-day warranty and a no fix, no fee promise.
-                        </div>
-                    </div>
-                    <div class="faq-item fade-in">
                         <button class="faq-question" aria-expanded="false">HOW LONG DO REPAIRS TAKE?</button>
                         <div class="faq-answer" role="region">
-                            Most common repairs, such as iPhone screen replacements, are completed within an hour.
-                            Console HDMI port replacements typically take about 3 hours. Complex board repairs may
-                            take 24-48 hours.
+                            Our most common repair is the HDMI port replacement, which takes around 2&ndash;3 hours.
+                            Bear in mind we work on an <strong>appointment basis</strong>, so this isn't a walk-in,
+                            while-you-wait service. More complex work &mdash; level 3 micro-soldering, data recovery,
+                            or intermittent problems needing PC diagnostics &mdash; can take 1&ndash;2 weeks.
                         </div>
                     </div>
                     <div class="faq-item fade-in">
@@ -1079,15 +1072,25 @@
                         <button class="faq-question" aria-expanded="false">WHAT DO YOU FIX?</button>
                         <div class="faq-answer" role="region">
                             Phones, laptops, PCs, gaming PCs, MacBooks, tablets, and consoles (PS5, Xbox,
-                            Switch). We also do data recovery and board-level micro-soldering.
+                            Switch). We also do data recovery and board-level micro-soldering. If your device or
+                            issue isn't listed, just inquire by <a href="mailto:hello@onlinefix.uk">email</a> or
+                            <a href="tel:+447940730537">phone</a> &mdash; chances are we can still help.
                         </div>
                     </div>
                     <div class="faq-item fade-in">
-                        <button class="faq-question" aria-expanded="false">HOW MUCH DOES IT COST?</button>
+                        <button class="faq-question" aria-expanded="false">MY CONSOLE WON'T SHOW VIDEO ON THE TV</button>
                         <div class="faq-answer" role="region">
-                            iPhone screens from &pound;45, laptop screens from &pound;60, PC diagnosis from
-                            &pound;30, console HDMI from &pound;60. <strong>No fix, no fee</strong> &mdash; if we
-                            can't fix it, you don't pay.
+                            This is usually a damaged HDMI port &mdash; the connector can be physically damaged or
+                            have pins broken off the board. It's one of our most common repairs. PS5 and Xbox Series
+                            X HDMI port replacement is <strong>&pound;80</strong>.
+                        </div>
+                    </div>
+                    <div class="faq-item fade-in">
+                        <button class="faq-question" aria-expanded="false">WHY DOES MY PS5 SHUT DOWN RANDOMLY?</button>
+                        <div class="faq-answer" role="region">
+                            Usually one of two things: the console is clogged up with dust, or the liquid metal
+                            thermal paste has oxidised and is causing a hotspot on the APU. We fix both with a full
+                            clean and thermal paste redo &mdash; <strong>&pound;70</strong> for PS5.
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
- Rewrite "how long do repairs take" around HDMI port replacement (2-3 hours, appointment basis) and 1-2 week complex/data recovery work
- Remove "what is OnlineFix" question (covered in About)
- Replace generic cost question with two issue-led questions: console no video (HDMI port, £80) and PS5 random shutdowns (clean + paste, £70)
- Invite email/phone inquiries for unlisted devices in "what do you fix"
- Keep FAQPage JSON-LD schema in sync with the visible FAQ


Claude-Session: https://claude.ai/code/session_01HsZGpoDYb1Y9EJXTnvzJah