### PR TITLE
Improve About page: intro story, timeline, expertise, values

### DIFF
--- a/about.html
+++ b/about.html
@@ -607,17 +607,24 @@
                 <div class="about-grid fade-in">
                     <div class="about-text">
                         <h2>Your Local Electronics Repair Expert</h2>
-                        <p>Welcome to OnlineFix! I'm <span class="highlight">Tomas</span>, a passionate electronics
-                            repair technician serving Guildford and the surrounding Surrey area. With years of hands-on
-                            experience and a genuine love for technology, I've dedicated my career to bringing your
-                            devices back to life.</p>
-                        <p>What started as a hobby tinkering with electronics has grown into a thriving repair business
-                            built on <span class="highlight">trust, quality, and customer satisfaction</span>. I believe
-                            that every device deserves a second chance, and I take pride in offering affordable,
-                            reliable repair solutions.</p>
-                        <p>Whether it's a cracked phone screen, a slow laptop, or a gaming console that won't start, I
-                            approach every repair with the same level of care and attention to detail. Your device isn't
-                            just another job to me - it's your connection to work, family, and the digital world.</p>
+                        <p>Welcome to OnlineFix! I'm <span class="highlight">Tomas</span>. I've been curious about
+                            technology and electronics for as long as I can remember &mdash; taking things apart to
+                            understand how they work started early and never really stopped.</p>
+                        <p>That curiosity became a career. I've worked in the industry for
+                            <span class="highlight">over 7 years</span>, across various high-street electronics repair
+                            shops here in Guildford. I still work as an advanced technician at
+                            <a href="https://www.google.com/maps/search/?api=1&amp;query=iSmash+Guildford"
+                                target="_blank" rel="noopener noreferrer">iSmash</a> in Guildford, helping improve how
+                            the workshop runs day to day.</p>
+                        <p>I started OnlineFix to help people find proper solutions to their needs and problems &mdash;
+                            with a <span class="highlight">transparent process and fair pricing</span>, not guesswork
+                            and inflated quotes.</p>
+                        <p>I'll be honest about why that matters. I genuinely believe around
+                            <span class="highlight">90% of high-street repair shops</span> don't have the skill or
+                            knowledge to complete even common repairs to the manufacturer's standard. Ignoring
+                            manufacturer guidance, or fitting cheap third-party parts to protect profit margins, is
+                            exactly what leaves people with new faults down the line. I'd rather do it properly the
+                            first time.</p>
                     </div>
                     <div class="about-profile">
                         <div class="profile-card">
@@ -688,9 +695,10 @@
                         <p>Added professional data recovery services for damaged storage devices.</p>
                     </div>
                     <div class="timeline-item fade-in" role="listitem">
-                        <div class="timeline-year">2023</div>
-                        <h3>500+ Repairs</h3>
-                        <p>Reached 500+ successful repairs with a 5-star customer satisfaction rating.</p>
+                        <div class="timeline-year">2026</div>
+                        <h3>Trusted Locally</h3>
+                        <p>Hundreds of repairs on, with 170+ reviews and a 5-star rating from customers across
+                            Guildford and Surrey.</p>
                     </div>
                 </div>
             </div>
@@ -717,9 +725,10 @@
                     </div>
                     <div class="value-item fade-in" role="listitem">
                         <div class="value-icon" aria-hidden="true"><i class="fas fa-clock"></i></div>
-                        <h3 class="value-title">Speed</h3>
-                        <p class="value-description">Same-day repairs whenever possible. We understand how important
-                            your devices are to your daily life.</p>
+                        <h3 class="value-title">Realistic</h3>
+                        <p class="value-description">No false promises on turnaround. Most common repairs are done
+                            within a few hours by appointment; complex board-level work can take longer &mdash; and
+                            I'll always give you an honest timeframe before any work begins.</p>
                     </div>
                     <div class="value-item fade-in" role="listitem">
                         <div class="value-icon" aria-hidden="true"><i class="fas fa-handshake"></i></div>
@@ -734,15 +743,15 @@
         <section class="cert-section" aria-labelledby="cert-heading">
             <div class="container">
                 <h2 class="section-title fade-in" id="cert-heading">EXPERTISE</h2>
-                <p class="section-subtitle fade-in">Certified Capabilities</p>
+                <p class="section-subtitle fade-in">Trained &amp; Specialised</p>
                 <div class="cert-grid">
                     <div class="cert-item fade-in">
                         <div class="cert-icon" aria-hidden="true"><i class="fab fa-apple"></i></div>
-                        <div class="cert-title">Apple Specialist</div>
+                        <div class="cert-title">Apple Trained</div>
                     </div>
                     <div class="cert-item fade-in">
                         <div class="cert-icon" aria-hidden="true"><i class="fab fa-android"></i></div>
-                        <div class="cert-title">Android Expert</div>
+                        <div class="cert-title">Samsung &amp; Google Trained</div>
                     </div>
                     <div class="cert-item fade-in">
                         <div class="cert-icon" aria-hidden="true"><i class="fas fa-laptop"></i></div>


### PR DESCRIPTION
- Rewrite the technician intro with a genuine, fact-led story (early curiosity, 7+ years in Guildford repair shops, advanced technician at iSmash with a Google Maps link, why OnlineFix exists, manufacturer- standard stance on parts/guidance)
- Refresh the stale 2023 "500+ Repairs" timeline milestone to a current 2026 "Trusted Locally" card citing 170+ reviews
- Reframe Expertise from "Certified Capabilities" to "Trained & Specialised"; update phone tiles to "Apple Trained" and "Samsung & Google Trained" to reflect manufacturer training
- Replace the "Speed / same-day" value with a realistic "Realistic" value aligned to the appointment-basis FAQ messaging


Claude-Session: https://claude.ai/code/session_01HsZGpoDYb1Y9EJXTnvzJah