### PR TITLE
Fix mobile layout issues with button margins and grid overflow

### DIFF
--- a/about.html
+++ b/about.html
@@ -487,7 +487,9 @@
             text-transform: uppercase;
             font-size: 0.9rem;
             border: 2px solid var(--hex-white);
-            margin: 0.5rem;
+            /* margin comes from core.css so its mobile width:100% + margin:0.5rem 0
+               pairing stays intact; overriding it here reintroduces an 8px
+               horizontal page overflow on phones */
             transition: all 0.1s;
         }
 
@@ -546,10 +548,13 @@
                 padding: 2rem 0;
             }
         .values-grid {
-                grid-template-columns: 1fr 1fr;
+                /* minmax(0,1fr) lets columns shrink below a word's min-content
+                   width on narrow screens / large font settings */
+                grid-template-columns: repeat(2, minmax(0, 1fr));
             }
         .value-item {
                 padding: 1.25rem 1rem;
+                overflow-wrap: break-word;
             }
         .value-title {
                 font-size: clamp(1.1rem, 4vw, 1.4rem);


### PR DESCRIPTION
## Summary
This PR fixes responsive layout issues on mobile devices by removing a conflicting margin declaration on buttons and improving grid column flexibility to prevent text overflow on narrow screens.

## Key Changes
- **Button margin**: Removed the `margin: 0.5rem` declaration from the button styles to prevent 8px horizontal page overflow on phones. The margin is already defined in core.css with mobile-appropriate `width: 100%` and `margin: 0.5rem 0` pairing, so the override was causing layout issues.
- **Grid columns**: Updated `.values-grid` to use `repeat(2, minmax(0, 1fr))` instead of `1fr 1fr` to allow columns to shrink below content's minimum width on narrow screens and with large font settings.
- **Text wrapping**: Added `overflow-wrap: break-word` to `.value-item` to ensure long words break properly within the constrained grid columns.

## Implementation Details
The changes preserve the intended mobile-first styling from core.css while fixing unintended side effects. The `minmax(0, 1fr)` pattern is a CSS Grid best practice that allows columns to shrink below their content's intrinsic minimum width, preventing overflow on constrained viewports.

https://claude.ai/code/session_01FZQPdJfXjjG7wcvLHoAuFs