### PR TITLE
Merge comparison matrix into Why Choose Us boxes on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -523,7 +523,7 @@
 
         .features-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            grid-template-columns: repeat(3, 1fr);
             gap: 2rem;
         }
 
@@ -953,22 +953,37 @@
                     <div class="feature-item fade-in" role="listitem">
                         <div class="feature-icon" aria-hidden="true"><i class="fas fa-clock"></i></div>
                         <h3 class="feature-title">Same-Day</h3>
-                        <p>Most repairs done the same day. No long waits.</p>
+                        <p>Most repairs done same-day or within 24&ndash;48 hours at our Guildford workshop.
+                            High street chains typically send devices away for 1&ndash;2 weeks.</p>
                     </div>
                     <div class="feature-item fade-in" role="listitem">
                         <div class="feature-icon" aria-hidden="true"><i class="fas fa-pound-sign"></i></div>
-                        <h3 class="feature-title">Fair Price</h3>
-                        <p>No hidden fees. You get a clear price before we start.</p>
+                        <h3 class="feature-title">No Fix, No Fee</h3>
+                        <p>Clear price before we start, and the diagnostic fee is credited towards your
+                            repair. If we can't fix it, you don't pay.</p>
                     </div>
                     <div class="feature-item fade-in" role="listitem">
-                        <div class="feature-icon" aria-hidden="true"><i class="fas fa-star"></i></div>
-                        <h3 class="feature-title">5-Star</h3>
-                        <p>Rated 5 stars by happy customers across Guildford and Surrey.</p>
+                        <div class="feature-icon" aria-hidden="true"><i class="fas fa-microchip"></i></div>
+                        <h3 class="feature-title">Board-Level</h3>
+                        <p>In-house micro-soldering for HDMI ports, logic boards and liquid damage &mdash;
+                            repairs most chains can't do, so your device gets fixed, not replaced.</p>
                     </div>
                     <div class="feature-item fade-in" role="listitem">
                         <div class="feature-icon" aria-hidden="true"><i class="fas fa-user-cog"></i></div>
                         <h3 class="feature-title">Expert</h3>
-                        <p>Tomas has years of hands-on repair skills you can trust.</p>
+                        <p>Every repair done by Tomas, owner and lead technician with 8+ years experience
+                            &mdash; not rotating staff or an outsourced depot.</p>
+                    </div>
+                    <div class="feature-item fade-in" role="listitem">
+                        <div class="feature-icon" aria-hidden="true"><i class="fas fa-shield-alt"></i></div>
+                        <h3 class="feature-title">Private</h3>
+                        <p>Your device stays with one technician in Guildford &mdash; never shipped around
+                            or handled by couriers and multiple staff.</p>
+                    </div>
+                    <div class="feature-item fade-in" role="listitem">
+                        <div class="feature-icon" aria-hidden="true"><i class="fas fa-star"></i></div>
+                        <h3 class="feature-title">5-Star</h3>
+                        <p>Rated 5.0 from 170+ Google reviews across Guildford and Surrey.</p>
                     </div>
                 </div>
             </div>
@@ -1039,63 +1054,6 @@
                         </svg>
                         <span>READ 170+ REVIEWS</span>
                     </a>
-                </div>
-            </div>
-        </section>
-
-        <!-- Comparison Matrix (GEO) -->
-        <section class="price-section" aria-labelledby="compare-heading">
-            <div class="container">
-                <h2 class="section-title fade-in" id="compare-heading">Why Choose OnlineFix Over a High Street Repair Chain?</h2>
-                <p class="price-answer fade-in">OnlineFix repairs most devices same-day or within 24&ndash;48 hours on-site at our Guildford workshop, whereas high street chains such as Currys, CeX and Timpson typically send devices away and can take up to 14 days. Here&apos;s how an independent specialist compares:</p>
-                <div class="price-table-wrap fade-in">
-                    <table class="price-table compare-table">
-                        <caption>OnlineFix vs high street repair chains &mdash; at a glance</caption>
-                        <thead>
-                            <tr>
-                                <th scope="col">What Matters</th>
-                                <th scope="col">OnlineFix (Guildford)</th>
-                                <th scope="col">High Street Chains</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <th scope="row">Turnaround time</th>
-                                <td data-label="OnlineFix">Same-day to 48 hours for most repairs</td>
-                                <td data-label="High street chains">Often 1&ndash;2 weeks &mdash; devices sent away to a depot</td>
-                            </tr>
-                            <tr>
-                                <th scope="row">Where the repair happens</th>
-                                <td data-label="OnlineFix">On-site at our Guildford workshop</td>
-                                <td data-label="High street chains">Usually shipped to a third-party repair centre</td>
-                            </tr>
-                            <tr>
-                                <th scope="row">Board-level micro-soldering</th>
-                                <td data-label="OnlineFix">Yes &mdash; HDMI ports, logic boards, liquid damage</td>
-                                <td data-label="High street chains">Rarely offered; devices often replaced instead of repaired</td>
-                            </tr>
-                            <tr>
-                                <th scope="row">Who does the work</th>
-                                <td data-label="OnlineFix">Tomas, owner &amp; lead technician with 8+ years experience</td>
-                                <td data-label="High street chains">Rotating staff or outsourced technicians</td>
-                            </tr>
-                            <tr>
-                                <th scope="row">Diagnostic fee</th>
-                                <td data-label="OnlineFix">Small fee, credited towards your repair</td>
-                                <td data-label="High street chains">Varies; often non-refundable</td>
-                            </tr>
-                            <tr>
-                                <th scope="row">No fix, no fee</th>
-                                <td data-label="OnlineFix">Yes, on all repairs</td>
-                                <td data-label="High street chains">Not guaranteed</td>
-                            </tr>
-                            <tr>
-                                <th scope="row">Data privacy</th>
-                                <td data-label="OnlineFix">Your device stays with one technician in Guildford</td>
-                                <td data-label="High street chains">Handled by couriers and multiple staff</td>
-                            </tr>
-                        </tbody>
-                    </table>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
Replace the separate comparison-table section with the existing feature-box design the site already uses: expand Why Choose Us from four to six boxes (Same-Day, No Fix No Fee, Board-Level, Expert, Private, 5-Star) and fold every comparison point — turnaround, on-site repair, micro-soldering, who does the work, diagnostic fee, data privacy — into their copy as declarative vs-high-street statements. Pin the grid to 3 columns on desktop for a balanced 3x2 layout; tablet and mobile behaviour unchanged.


Claude-Session: https://claude.ai/code/session_01N3cKajRUKDFx2AFyztzseJ