### PR TITLE
Fix iPhone page claims: express service wording and open-ended model range

### DIFF
--- a/iphone-repair.html
+++ b/iphone-repair.html
@@ -11,9 +11,9 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https://www.googletagmanager.com https://*.google-analytics.com; connect-src 'self' https://cloudflareinsights.com https://*.google-analytics.com https://www.googletagmanager.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'">
 
     <!-- SEO Meta Tags - IPHONE REPAIR LANDING PAGE -->
-    <title>Phone &amp; iPhone Repair Guildford | Same-Day Fix | OnlineFix</title>
-    <meta name="description" content="Phone &amp; iPhone repair in Guildford, Surrey. Screen replacement from £45, battery swap, charging port fix &amp; water damage recovery. Same-day, 90-day warranty. Call 07940 730537.">
-    <meta name="keywords" content="phone repair Guildford, iPhone repair Guildford, phone repair near me, phone repair shops near me, iPhone screen replacement Surrey, iPhone battery replacement Guildford, iPhone charging port repair, phone repairs Guildford, phone screen repair near me, Samsung repair Guildford, Google Pixel repair, same day phone repair Guildford, mobile phone repair Guildford">
+    <title>Phone &amp; iPhone Repair Guildford | Express Fix | OnlineFix</title>
+    <meta name="description" content="Phone &amp; iPhone repair in Guildford, Surrey. Screen replacement from £45, battery swap, charging port fix &amp; water damage recovery. Express service, 90-day warranty. Call 07940 730537.">
+    <meta name="keywords" content="phone repair Guildford, iPhone repair Guildford, phone repair near me, phone repair shops near me, iPhone screen replacement Surrey, iPhone battery replacement Guildford, iPhone charging port repair, phone repairs Guildford, phone screen repair near me, Samsung repair Guildford, Google Pixel repair, express phone repair Guildford, mobile phone repair Guildford">
     <meta name="author" content="OnlineFix - Tomas">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <link rel="canonical" href="https://onlinefix.co.uk/iphone-repair.html">
@@ -29,8 +29,8 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://onlinefix.co.uk/iphone-repair.html">
     <meta property="og:site_name" content="OnlineFix Guildford">
-    <meta property="og:title" content="Phone &amp; iPhone Repair Guildford | Screen &amp; Battery Fix | Same-Day">
-    <meta property="og:description" content="Broken phone? Expert screen replacement, battery swap, charging port repair &amp; water damage recovery in Guildford. Same-day service. 90-day warranty.">
+    <meta property="og:title" content="Phone &amp; iPhone Repair Guildford | Screen &amp; Battery Fix | Express">
+    <meta property="og:description" content="Broken phone? Expert screen replacement, battery swap, charging port repair &amp; water damage recovery in Guildford. Express service. 90-day warranty.">
     <meta property="og:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.webp?v=2">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="670">
@@ -39,8 +39,8 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://onlinefix.co.uk/iphone-repair.html">
-    <meta name="twitter:title" content="iPhone Repair Guildford | Same-Day Fix | 90-Day Warranty">
-    <meta name="twitter:description" content="iPhone screen, battery &amp; charging port repair in Guildford. Same-day service. 90-day warranty. Appointment only.">
+    <meta name="twitter:title" content="iPhone Repair Guildford | Express Fix | 90-Day Warranty">
+    <meta name="twitter:description" content="iPhone screen, battery &amp; charging port repair in Guildford. Express service. 90-day warranty. Appointment only.">
     <meta name="twitter:image" content="https://onlinefix.co.uk/images/onlinefix-og-image.webp?v=2">
 
     <!-- Favicon -->
@@ -99,7 +99,7 @@
         "@context": "https://schema.org",
         "@type": "WebPage",
         "name": "Phone & iPhone Repair Guildford | Screen & Battery Fix Surrey",
-        "description": "Expert phone and iPhone repair in Guildford, Surrey. Same-day screen replacement, battery swap, charging port fix, water damage recovery. 90-day warranty. Serving Guildford, Woking, Godalming and Farnham.",
+        "description": "Expert phone and iPhone repair in Guildford, Surrey. Express screen replacement, battery swap, charging port fix, water damage recovery. 90-day warranty. Serving Guildford, Woking, Godalming and Farnham.",
         "url": "https://onlinefix.co.uk/iphone-repair.html",
         "isPartOf": {
             "@type": "WebSite",
@@ -318,7 +318,7 @@
                 "name": "Do you repair other phone brands besides iPhone?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes, OnlineFix repairs all major phone brands including Samsung Galaxy, Google Pixel, Huawei, OnePlus, and more. We handle screen replacements, battery swaps, charging port repairs, and water damage recovery for all Android and iOS devices. Same-day service available at our Guildford shop. Call 07940 730537 to book."
+                    "text": "Yes, OnlineFix repairs all major phone brands including Samsung Galaxy, Google Pixel, Huawei, OnePlus, and more. We handle screen replacements, battery swaps, charging port repairs, and water damage recovery for all Android and iOS devices. Express service available at our Guildford shop. Call 07940 730537 to book."
                 }
             }
         ]
@@ -330,7 +330,7 @@
     {
         "@context": "https://schema.org",
         "@type": "WebPage",
-        "name": "Phone & iPhone Repair Guildford — Same-Day Screen & Battery Fix",
+        "name": "Phone & iPhone Repair Guildford — Express Screen & Battery Fix",
         "speakable": {
             "@type": "SpeakableSpecification",
             "cssSelector": [".page-subtitle", ".faq-answer", ".ai-summary"]
@@ -348,7 +348,7 @@
         "@context": "https://schema.org",
         "@type": "HowTo",
         "name": "How to get your iPhone or phone repaired at OnlineFix Guildford",
-        "description": "Step-by-step process for getting your iPhone or smartphone repaired at OnlineFix in Guildford, Surrey. Same-day screen and battery repairs.",
+        "description": "Step-by-step process for getting your iPhone or smartphone repaired at OnlineFix in Guildford, Surrey. Express screen and battery repairs.",
         "totalTime": "PT1H",
         "estimatedCost": {
             "@type": "MonetaryAmount",
@@ -653,7 +653,7 @@
                 <nav class="breadcrumbs" aria-label="Breadcrumb"><a href="/">Home</a> <span aria-hidden="true">&rsaquo;</span> <a href="/services.html">Services</a> <span aria-hidden="true">&rsaquo;</span> <span aria-current="page">Phone Repair</span></nav>
             <div class="page-header-box fade-in">
                 <h1 class="page-title">IPHONE <span>REPAIR</span> GUILDFORD</h1>
-                <p class="page-subtitle">Same-Day iPhone Screen &amp; Battery Repair // <span class="nosplit">Transparent Pricing</span> // <span class="nosplit">90-Day Warranty</span></p>
+                <p class="page-subtitle">Express iPhone Screen &amp; Battery Repair // <span class="nosplit">Transparent Pricing</span> // <span class="nosplit">90-Day Warranty</span></p>
                     <div class="header-cta-row">
                         <a href="tel:+447940730537" class="cta-button">Call 07940 730537</a>
                         <a href="https://wa.me/447940730537" target="_blank" rel="noopener noreferrer" class="cta-button cta-secondary">WhatsApp</a>
@@ -849,7 +849,7 @@
         <section class="emergency-section" aria-label="Emergency repair contact">
             <div class="container">
                 <h2>IPHONE BROKEN?</h2>
-                <p>Don't overpay at Apple — get it fixed fast. Same-day repairs available. Diagnostic fee credited towards your repair. Call to book a drop-off.</p>
+                <p>Don't overpay at Apple — get it fixed fast. Express repairs available. Diagnostic fee credited towards your repair. Call to book a drop-off.</p>
                 <a href="tel:+447940730537" class="emergency-btn">
                     <i class="fas fa-phone-alt" aria-hidden="true"></i> Call to Book — 07940 730537
                 </a>
@@ -869,8 +869,8 @@
                     </div>
                     <div class="why-item fade-in">
                         <div class="why-icon"><i class="fas fa-bolt" aria-hidden="true"></i></div>
-                        <div class="why-title">Same-Day Repairs</div>
-                        <p class="why-description">Screen and battery swaps done in under an hour. Unlike Apple Store who quote 3-5 business days, we repair while you wait.</p>
+                        <div class="why-title">Express Repairs</div>
+                        <p class="why-description">Parts are ordered in for your exact model, then fitted in under an hour while you wait — unlike Apple Store who quote 3-5 business days.</p>
                     </div>
                     <div class="why-item fade-in">
                         <div class="why-icon"><i class="fas fa-certificate" aria-hidden="true"></i></div>
@@ -888,7 +888,7 @@
                     <div class="why-vs-row">
                         <div class="why-vs-col">
                             <div class="why-vs-label">OnlineFix</div>
-                            <div class="why-vs-value highlight">Screen repair from &pound;45<br>Same-day, often under 1 hour<br>Diagnostic fee credited to repair<br>90-day warranty<br>Easy scheduled drop-offs</div>
+                            <div class="why-vs-value highlight">Screen repair from &pound;45<br>Express, often under 1 hour<br>Diagnostic fee credited to repair<br>90-day warranty<br>Easy scheduled drop-offs</div>
                         </div>
                         <div class="why-vs-col">
                             <div class="why-vs-label">Apple Store / Others</div>
@@ -1027,7 +1027,7 @@
                     <div class="faq-item fade-in">
                         <button class="faq-question" aria-expanded="false">Do you repair other phone brands besides iPhone?</button>
                         <div class="faq-answer" role="region">
-                            <p>Yes, we repair <strong>all major phone brands</strong> including Samsung Galaxy, Google Pixel, Huawei, OnePlus, and more. We handle screen replacements, battery swaps, charging port repairs, and water damage recovery for all Android and iOS devices. <strong>Same-day service</strong> available at our Guildford shop. <strong>Call 07940 730537</strong> to book.</p>
+                            <p>Yes, we repair <strong>all major phone brands</strong> including Samsung Galaxy, Google Pixel, Huawei, OnePlus, and more. We handle screen replacements, battery swaps, charging port repairs, and water damage recovery for all Android and iOS devices. <strong>Express service</strong> available at our Guildford shop. <strong>Call 07940 730537</strong> to book.</p>
                         </div>
                     </div>
                 </div>

--- a/iphone-repair.html
+++ b/iphone-repair.html
@@ -169,7 +169,7 @@
                                 "itemOffered": {
                                         "@type": "Service",
                                         "name": "iPhone Screen Replacement",
-                                        "description": "Professional iPhone screen replacement for cracked, unresponsive or black display screens on all iPhone models from iPhone 8 to iPhone 16 Pro Max"
+                                        "description": "Professional iPhone screen replacement for cracked, unresponsive or black display screens on all iPhone models from the iPhone 8 to the latest releases"
                                 },
                                 "priceSpecification": {
                                         "@type": "UnitPriceSpecification",
@@ -1037,7 +1037,7 @@
             <div class="container">
                 <div class="summary-box">
                     <p class="summary-label">// Phone repair &mdash; at a glance</p>
-                    <p><strong>OnlineFix</strong> is a phone and iPhone repair shop in <strong>Guildford, Surrey</strong>, run by Tomas, an electronics repair technician since 2018. We repair <strong>all iPhone models from iPhone 8 to iPhone 16 Pro Max</strong>, plus <strong>Samsung Galaxy, Google Pixel, Huawei, OnePlus</strong> and other Android phones. Most phone repairs are completed <strong>same-day, often within 30&ndash;60 minutes</strong>, with a <strong>90-day warranty</strong> and a <strong>no fix, no fee</strong> policy. Appointment only &mdash; call <strong>07940 730537</strong>. Serving Guildford, Woking, Godalming, Farnham and surrounding Surrey areas.</p>
+                    <p><strong>OnlineFix</strong> is a phone and iPhone repair shop in <strong>Guildford, Surrey</strong>, run by Tomas, an electronics repair technician since 2018. We repair <strong>all iPhone models, from the iPhone 8 to the latest releases</strong>, plus <strong>Samsung Galaxy, Google Pixel, Huawei, OnePlus</strong> and other Android phones. Parts are ordered in for your exact model, then your repair is completed as an <strong>express service &mdash; often within 30&ndash;60 minutes</strong> of drop-off, with a <strong>90-day warranty</strong> and a <strong>no fix, no fee</strong> policy. Appointment only &mdash; call <strong>07940 730537</strong>. Serving Guildford, Woking, Godalming, Farnham and surrounding Surrey areas.</p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
- "At a glance" box: "all iPhone models from iPhone 8 to iPhone 16 Pro Max" implied a cap — now reads "from the iPhone 8 to the latest releases" (also fixed in the screen-replacement schema description)
- Replaced every "same-day" claim on iphone-repair.html (title, meta/OG/Twitter tags, keywords, JSON-LD schema, page subtitle, hero copy, feature tile, comparison table, FAQ) with express-service wording: parts are ordered in for the exact model, then fitted in under an hour at drop-off — phone repairs are rarely same-day since parts almost always need ordering
- No styling or script changes; single-page content edit, so no cache-buster bumps needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ax3oxkHzA2cowKVJ7y957

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ax3oxkHzA2cowKVJ7y957)_