### PR TITLE
Correct payment methods to cash and bank transfer only

### DIFF
--- a/booking-terms.html
+++ b/booking-terms.html
@@ -222,7 +222,8 @@
                             <li>The booking form does not require payment</li>
                             <li>Diagnostics are free for most devices and never chargeable without your prior consent</li>
                             <li>Once we've quoted you, work begins only when you confirm</li>
-                            <li>Payment is due on collection, by card or bank transfer</li>
+                            <li>Payment is due on collection, by cash or bank transfer — we do not accept credit or debit cards, Apple Pay or Google Pay</li>
+                            <li>If you need an invoice, for business expenses or an insurance claim, just ask and we'll issue one</li>
                             <li>If you decide not to proceed after diagnostics, there's no charge — we just hand the device back</li>
                         </ul>
                     </div>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
             "https://onlinefix.co.uk/images/onlinefix-logo.webp?v=2"
         ],
         "logo": "https://onlinefix.co.uk/images/onlinefix-logo.webp?v=2",
-        "paymentAccepted": "Cash, Credit Card, Debit Card, Apple Pay",
+        "paymentAccepted": "Cash, Bank Transfer",
         "currenciesAccepted": "GBP",
         "foundingDate": "2018",
         "founder": {
@@ -319,6 +319,13 @@
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "Yes, OnlineFix operates on an appointment-only basis at our Guildford location to ensure dedicated attention to your device. We do not accept walk-ins. Please call us on 07940 730537 or send a message to arrange a convenient drop-off time."
+        }
+      }, {
+        "@type": "Question",
+        "name": "How can I pay for my repair at OnlineFix?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "OnlineFix accepts cash or bank transfer only. We do not accept credit or debit cards, Apple Pay or Google Pay. Payment is due on collection, once you have seen the device working and you are happy with the repair — the booking itself requires no payment and no deposit. If you need an invoice, for business expenses or an insurance claim, just ask and we will issue one."
         }
       }, {
         "@type": "Question",
@@ -1086,6 +1093,16 @@
                         <div class="faq-answer" role="region">
                             Yes, <strong>appointment only</strong>. We do not accept walk-ins. Please get in touch
                             to arrange a drop-off time that suits you.
+                        </div>
+                    </div>
+                    <div class="faq-item fade-in">
+                        <button class="faq-question" aria-expanded="false">HOW CAN I PAY?</button>
+                        <div class="faq-answer" role="region">
+                            <strong>Cash or bank transfer</strong> only &mdash; we don't accept credit or debit
+                            cards, Apple Pay or Google Pay. Payment is due on collection, once you've seen the
+                            device working and you're happy with the repair. Booking takes no payment and no
+                            deposit. Need an <strong>invoice</strong> for business expenses or an insurance
+                            claim? Just ask and we'll issue one.
                         </div>
                     </div>
                     <div class="faq-item fade-in">

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7,6 +7,7 @@ Key facts:
 - Location: 13 Quarry Street, Guildford, Surrey, GU1 3UY, United Kingdom. Also serves Woking, Farnham, Godalming and the rest of Surrey.
 - Booking: appointment only — phone 07940 730537 (or message) to arrange a drop-off time. Walk-ins are not accepted.
 - Pricing: depends on the device and fault — see per-service prices below. Simple servicing and upgrades sit at the lower end; complex board-level or motherboard repairs start from £90 and can realistically take 1–2 weeks. A small diagnostic fee applies and is credited towards the repair. No fix, no fee.
+- Payment: cash or bank transfer only — credit and debit cards, Apple Pay and Google Pay are not accepted. Payment is due on collection, after you have checked the repair. Invoices are available on request.
 - Warranty: 90-day warranty on all repairs.
 - Turnaround: most repairs same-day or within 24–48 hours, on-site at the Guildford workshop (devices are not sent away). Complex board-level work or data recovery can take 1–2 weeks.
 - Specialities: board-level micro-soldering, PS5/PS4/Xbox HDMI port replacement (PS5 HDMI £80), Blue Light of Death repair, MacBook logic board repair, data recovery.
@@ -41,6 +42,10 @@ Yes, OnlineFix offers comprehensive warranties on all repairs ranging from 3 mon
 **Do I need to book an appointment for repair?**
 
 Yes, OnlineFix operates on an appointment-only basis at our Guildford location to ensure dedicated attention to your device. We do not accept walk-ins. Please call us on 07940 730537 or send a message to arrange a convenient drop-off time.
+
+**How can I pay for my repair at OnlineFix?**
+
+OnlineFix accepts cash or bank transfer only. We do not accept credit or debit cards, Apple Pay or Google Pay. Payment is due on collection, once you have seen the device working and you are happy with the repair — the booking itself requires no payment and no deposit. If you need an invoice, for business expenses or an insurance claim, just ask and we will issue one.
 
 **What devices does OnlineFix repair?**
 

--- a/llms.txt
+++ b/llms.txt
@@ -7,6 +7,7 @@ Key facts:
 - Location: 13 Quarry Street, Guildford, Surrey, GU1 3UY, United Kingdom. Also serves Woking, Farnham, Godalming and the rest of Surrey.
 - Booking: appointment only — phone 07940 730537 (or message) to arrange a drop-off time. Walk-ins are not accepted.
 - Pricing: depends on the device and fault — see per-service prices below. Simple servicing and upgrades sit at the lower end; complex board-level or motherboard repairs start from £90 and can realistically take 1–2 weeks. A small diagnostic fee applies and is credited towards the repair. No fix, no fee.
+- Payment: cash or bank transfer only — credit and debit cards, Apple Pay and Google Pay are not accepted. Payment is due on collection, after you have checked the repair. Invoices are available on request.
 - Warranty: 90-day warranty on all repairs.
 - Turnaround: most repairs same-day or within 24–48 hours, on-site at the Guildford workshop (devices are not sent away). Complex board-level work or data recovery can take 1–2 weeks.
 - Specialities: board-level micro-soldering, PS5/PS4/Xbox HDMI port replacement (PS5 HDMI £80), Blue Light of Death repair, MacBook logic board repair, data recovery.


### PR DESCRIPTION
## Problem

The homepage `LocalBusiness` JSON-LD advertised payment methods we don't accept:

```json
"paymentAccepted": "Cash, Credit Card, Debit Card, Apple Pay"
```

That field is what search engines, directories and AI answer engines scrape to populate business listings, and it was the **only** machine-readable payment statement anywhere on the site. Nothing contradicted it, which is why third-party listings have been republishing the wrong methods.

One other spot was wrong: `booking-terms.html` told customers payment was due "by card or bank transfer".

We only take **cash or bank transfer**, with an invoice available on request.

## Changes

- **`index.html`** — `paymentAccepted` is now `"Cash, Bank Transfer"`. Limited to the two real methods, since scrapers often render this field verbatim.
- **`index.html`** — new "How can I pay?" entry in both the `FAQPage` schema and the visible FAQ accordion. Names the accepted methods, notes the invoice option, and states explicitly that cards, Apple Pay and Google Pay are not accepted.
- **`booking-terms.html`** — payment on collection is cash or bank transfer; added a line about invoices.
- **`llms.txt`** — added a Payment key fact, since this file is written specifically for AI crawlers.
- **`llms-full.txt`** — regenerated via `scripts/build-llms-full.mjs`.

### Why the explicit negative

Simply deleting the wrong methods leaves a blank that aggregators fill with guesses. Stating "we do not accept credit or debit cards, Apple Pay or Google Pay" gives crawlers something to correct against. This is why "Apple Pay" still appears in the diff — always inside a "not accepted" sentence.

## Verification

- JSON-LD across all 22 HTML files parses cleanly
- Served page confirmed to expose `paymentAccepted: Cash, Bank Transfer`
- FAQ accordion opens correctly with styling consistent with existing entries (screenshot checked locally)

## Note — outside this change

The Google Business Profile has its own payment-methods field that this repo doesn't control, and for local search it likely carries more weight than the site schema. Worth updating there too, otherwise the old data keeps flowing from that source. Already-scraped directory listings may also need re-crawling before they pick up the correction.

---
_Generated by [Claude Code](https://claude.ai/code/session_018bpxi9SzqQagMCbiS7NNVF)_